### PR TITLE
Update install process: hint before downloading

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -84,11 +84,11 @@ install_component "curl"
 install_component "unzip"
 
 if [ -n "${PROXY}" ]; then
-  curl -x ${PROXY} -L -H "Cache-Control: no-cache" -o "/tmp/v2ray/v2ray.zip" ${DOWNLOAD_LINK}
   echo "Downloading ${DOWNLOAD_LINK} via proxy ${PROXY}."
+  curl -x ${PROXY} -L -H "Cache-Control: no-cache" -o "/tmp/v2ray/v2ray.zip" ${DOWNLOAD_LINK}
 else
-  curl -L -H "Cache-Control: no-cache" -o "/tmp/v2ray/v2ray.zip" ${DOWNLOAD_LINK}
   echo "Downloading ${DOWNLOAD_LINK} directly."
+  curl -L -H "Cache-Control: no-cache" -o "/tmp/v2ray/v2ray.zip" ${DOWNLOAD_LINK}
 fi
 unzip "/tmp/v2ray/v2ray.zip" -d "/tmp/v2ray/"
 


### PR DESCRIPTION
Hint downloading address before installing, in case the download is blocked and the user may manually overwrite the installation process. (Otherwise, the "downloading" hint will never appear when download is blocked.)