### PR TITLE
Fixed: internal.CreateOutboundHandler should return ErrorProxyNotFound if !found instead of ErrorNameExists

### DIFF
--- a/proxy/internal/handler_cache.go
+++ b/proxy/internal/handler_cache.go
@@ -63,7 +63,7 @@ func CreateInboundHandler(name string, space app.Space, rawConfig []byte) (proxy
 func CreateOutboundHandler(name string, space app.Space, rawConfig []byte) (proxy.OutboundHandler, error) {
 	creator, found := outboundFactories[name]
 	if !found {
-		return nil, ErrorNameExists
+		return nil, ErrorProxyNotFound
 	}
 
 	if len(rawConfig) > 0 {


### PR DESCRIPTION
Fixed: internal.CreateOutboundHandler should return ErrorProxyNotFound if !found instead of ErrorNameExists.

No expected compatibility damage.

This is a fix for a non-critical bug. No more explanation is necessary. 