### PR TITLE
Add KCP(UDPSession) as a transport for v2ray, reslove #162

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,11 +18,15 @@ type InboundHandlerMeta struct {
 	Tag     string
 	Address v2net.Address
 	Port    v2net.Port
+	//Whether this proxy support KCP connections
+	KcpSupported bool
 }
 
 type OutboundHandlerMeta struct {
 	Tag     string
 	Address v2net.Address
+	//Whether this proxy support KCP connections
+	KcpSupported bool
 }
 
 // An InboundHandler handles inbound network connections to V2Ray.

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -248,6 +248,8 @@ func init() {
 				handler.inboundHandlerManager = space.GetApp(proxyman.APP_ID_INBOUND_MANAGER).(proxyman.InboundHandlerManager)
 			}
 
+			handler.setProxyCap()
+
 			return handler, nil
 		})
 }

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -220,7 +220,9 @@ func (this *VMessInboundHandler) HandleConnection(connection *hub.Connection) {
 
 	readFinish.Lock()
 }
-
+func (this *VMessInboundHandler) setProxyCap() {
+	this.meta.KcpSupported = true
+}
 func init() {
 	internal.MustRegisterInboundHandlerCreator("vmess",
 		func(space app.Space, rawConfig interface{}, meta *proxy.InboundHandlerMeta) (proxy.InboundHandler, error) {

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -106,7 +106,7 @@ func (this *VMessInboundHandler) Start() error {
 		return nil
 	}
 
-	tcpListener, err := hub.ListenTCP(this.meta.Address, this.meta.Port, this.HandleConnection, nil)
+	tcpListener, err := hub.ListenTCP6(this.meta.Address, this.meta.Port, this.HandleConnection, this.meta, nil)
 	if err != nil {
 		log.Error("Unable to listen tcp ", this.meta.Address, ":", this.meta.Port, ": ", err)
 		return err

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -161,9 +161,14 @@ func init() {
 	internal.MustRegisterOutboundHandlerCreator("vmess",
 		func(space app.Space, rawConfig interface{}, meta *proxy.OutboundHandlerMeta) (proxy.OutboundHandler, error) {
 			vOutConfig := rawConfig.(*Config)
-			return &VMessOutboundHandler{
+
+			handler := &VMessOutboundHandler{
 				receiverManager: NewReceiverManager(vOutConfig.Receivers),
 				meta:            meta,
-			}, nil
+			}
+
+			handler.setProxyCap()
+
+			return handler, nil
 		})
 }

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -154,7 +154,9 @@ func (this *VMessOutboundHandler) handleResponse(session *raw.ClientSession, con
 
 	return
 }
-
+func (this *VMessOutboundHandler) setProxyCap() {
+	this.meta.KcpSupported = true
+}
 func init() {
 	internal.MustRegisterOutboundHandlerCreator("vmess",
 		func(space app.Space, rawConfig interface{}, meta *proxy.OutboundHandlerMeta) (proxy.OutboundHandler, error) {

--- a/proxy/vmess/outbound/outbound.go
+++ b/proxy/vmess/outbound/outbound.go
@@ -34,7 +34,7 @@ func (this *VMessOutboundHandler) Dispatch(target v2net.Destination, payload *al
 
 	err := retry.Timed(5, 100).On(func() error {
 		rec = this.receiverManager.PickReceiver()
-		rawConn, err := hub.Dial(this.meta.Address, rec.Destination)
+		rawConn, err := hub.Dial3(this.meta.Address, rec.Destination, this.meta)
 		if err != nil {
 			return err
 		}

--- a/transport/config.go
+++ b/transport/config.go
@@ -17,6 +17,7 @@ func (this *Config) Apply() error {
 	enableKcp = this.enableKcp
 	if enableKcp {
 		KcpConfig = this.kcpConfig
+		connectionReuse = false
 	}
 	return nil
 }

--- a/transport/config.go
+++ b/transport/config.go
@@ -1,12 +1,20 @@
 package transport
 
+import "github.com/v2ray/v2ray-core/transport/hub/kcpv"
+
 type Config struct {
 	ConnectionReuse bool
+	enableKcp       bool
+	kcpConfig       *kcpv.Config
 }
 
 func (this *Config) Apply() error {
 	if this.ConnectionReuse {
 		connectionReuse = true
+	}
+	enableKcp = this.enableKcp
+	if enableKcp {
+		KcpConfig = this.kcpConfig
 	}
 	return nil
 }

--- a/transport/config.go
+++ b/transport/config.go
@@ -17,6 +17,13 @@ func (this *Config) Apply() error {
 	enableKcp = this.enableKcp
 	if enableKcp {
 		KcpConfig = this.kcpConfig
+		/*
+			KCP do not support connectionReuse,
+			it is mandatory to set connectionReuse to false
+			Since KCP have no handshake and
+			does not SlowStart, there isn't benefit to
+			use that anyway.
+		*/
 		connectionReuse = false
 	}
 	return nil

--- a/transport/config_json.go
+++ b/transport/config_json.go
@@ -23,6 +23,10 @@ func (this *Config) UnmarshalJSON(data []byte) error {
 	}
 	this.ConnectionReuse = jsonConfig.ConnectionReuse
 	this.enableKcp = jsonConfig.EnableKcp
-	this.kcpConfig = kcpConfig
+	this.kcpConfig = jsonConfig.KcpConfig
+	if jsonConfig.KcpConfig.AdvancedConfig == nil {
+		jsonConfig.KcpConfig.AdvancedConfig = kcpv.DefaultAdvancedConfigs
+	}
+
 	return nil
 }

--- a/transport/config_json.go
+++ b/transport/config_json.go
@@ -5,6 +5,7 @@ package transport
 import (
 	"encoding/json"
 
+	"github.com/v2ray/v2ray-core/common/log"
 	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
 )
 
@@ -23,9 +24,15 @@ func (this *Config) UnmarshalJSON(data []byte) error {
 	}
 	this.ConnectionReuse = jsonConfig.ConnectionReuse
 	this.enableKcp = jsonConfig.EnableKcp
-	this.kcpConfig = jsonConfig.KcpConfig
-	if jsonConfig.KcpConfig.AdvancedConfigs == nil {
-		jsonConfig.KcpConfig.AdvancedConfigs = kcpv.DefaultAdvancedConfigs
+	if jsonConfig.KcpConfig != nil {
+		this.kcpConfig = jsonConfig.KcpConfig
+		if jsonConfig.KcpConfig.AdvancedConfigs == nil {
+			jsonConfig.KcpConfig.AdvancedConfigs = kcpv.DefaultAdvancedConfigs
+		}
+	} else {
+		if jsonConfig.EnableKcp {
+			log.Error("transport: You have enabled KCP but no configure is given")
+		}
 	}
 
 	return nil

--- a/transport/config_json.go
+++ b/transport/config_json.go
@@ -24,8 +24,8 @@ func (this *Config) UnmarshalJSON(data []byte) error {
 	this.ConnectionReuse = jsonConfig.ConnectionReuse
 	this.enableKcp = jsonConfig.EnableKcp
 	this.kcpConfig = jsonConfig.KcpConfig
-	if jsonConfig.KcpConfig.AdvancedConfig == nil {
-		jsonConfig.KcpConfig.AdvancedConfig = kcpv.DefaultAdvancedConfigs
+	if jsonConfig.KcpConfig.AdvancedConfigs == nil {
+		jsonConfig.KcpConfig.AdvancedConfigs = kcpv.DefaultAdvancedConfigs
 	}
 
 	return nil

--- a/transport/config_json.go
+++ b/transport/config_json.go
@@ -2,18 +2,27 @@
 
 package transport
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
+)
 
 func (this *Config) UnmarshalJSON(data []byte) error {
 	type JsonConfig struct {
-		ConnectionReuse bool `json:"connectionReuse"`
+		ConnectionReuse bool         `json:"connectionReuse"`
+		EnableKcp       bool         `json:"EnableKCP,omitempty"`
+		KcpConfig       *kcpv.Config `json:"KcpConfig,omitempty"`
 	}
 	jsonConfig := &JsonConfig{
 		ConnectionReuse: true,
+		EnableKcp:       false,
 	}
 	if err := json.Unmarshal(data, jsonConfig); err != nil {
 		return err
 	}
 	this.ConnectionReuse = jsonConfig.ConnectionReuse
+	this.enableKcp = jsonConfig.EnableKcp
+	this.kcpConfig = kcpConfig
 	return nil
 }

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -64,19 +64,19 @@ func DialWithoutCache(src v2net.Address, dest v2net.Destination) (net.Conn, erro
 	return dialer.Dial(dest.Network().String(), dest.NetAddr())
 }
 
-func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (*Connection, error) {
+func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (*Connection, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
 		DialKCP3(src, dest, proxyMeta)
 	}
 	return Dial(src, dest)
 }
-func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (net.Conn, error) {
+func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (net.Conn, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
 	}
 	return DialWithoutCache(src, dest)
 }
 
-func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (*Connection, error) {
+func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (*Connection, error) {
 	if src == nil {
 		src = v2net.AnyIP
 	}

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -64,19 +64,19 @@ func DialWithoutCache(src v2net.Address, dest v2net.Destination) (net.Conn, erro
 	return dialer.Dial(dest.Network().String(), dest.NetAddr())
 }
 
-func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (*Connection, error) {
+func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundHandlerMeta) (*Connection, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
 		DialKCP3(src, dest, proxyMeta)
 	}
 	return Dial(src, dest)
 }
-func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (net.Conn, error) {
+func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundHandlerMeta) (net.Conn, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
 	}
 	return DialWithoutCache(src, dest)
 }
 
-func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.OutboundHandlerMeta) (*Connection, error) {
+func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundHandlerMeta) (*Connection, error) {
 	if src == nil {
 		src = v2net.AnyIP
 	}

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -66,7 +66,7 @@ func DialWithoutCache(src v2net.Address, dest v2net.Destination) (net.Conn, erro
 
 func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundHandlerMeta) (*Connection, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
-		DialKCP3(src, dest, proxyMeta)
+		return DialKCP3(src, dest, proxyMeta)
 	}
 	return Dial(src, dest)
 }

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -72,6 +72,7 @@ func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundH
 }
 func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.OutboundHandlerMeta) (net.Conn, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
+		return DialKCPWithoutCache(src, dest)
 	}
 	return DialWithoutCache(src, dest)
 }

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -82,16 +82,9 @@ func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta *proxy.Outbou
 		src = v2net.AnyIP
 	}
 	id := src.String() + "-" + dest.NetAddr()
-	var conn net.Conn
-	if dest.IsTCP() && transport.IsConnectionReusable() {
-		conn = globalCache.Get(id)
-	}
-	if conn == nil {
-		var err error
-		conn, err = DialWithoutCache3(src, dest, proxyMeta)
-		if err != nil {
-			return nil, err
-		}
+	conn, err := DialWithoutCache3(src, dest, proxyMeta)
+	if err != nil {
+		return nil, err
 	}
 	return &Connection{
 		dest:     id,

--- a/transport/hub/dialer.go
+++ b/transport/hub/dialer.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	v2net "github.com/v2ray/v2ray-core/common/net"
+	"github.com/v2ray/v2ray-core/proxy"
 	"github.com/v2ray/v2ray-core/transport"
 )
 
@@ -61,4 +62,47 @@ func DialWithoutCache(src v2net.Address, dest v2net.Destination) (net.Conn, erro
 	}
 
 	return dialer.Dial(dest.Network().String(), dest.NetAddr())
+}
+
+func Dial3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (*Connection, error) {
+	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
+		DialKCP3(src, dest, proxyMeta)
+	}
+	return Dial(src, dest)
+}
+func DialWithoutCache3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (net.Conn, error) {
+	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
+	}
+	return DialWithoutCache(src, dest)
+}
+
+func DialKCP3(src v2net.Address, dest v2net.Destination, proxyMeta proxy.InboundHandlerMeta) (*Connection, error) {
+	if src == nil {
+		src = v2net.AnyIP
+	}
+	id := src.String() + "-" + dest.NetAddr()
+	var conn net.Conn
+	if dest.IsTCP() && transport.IsConnectionReusable() {
+		conn = globalCache.Get(id)
+	}
+	if conn == nil {
+		var err error
+		conn, err = DialWithoutCache3(src, dest, proxyMeta)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &Connection{
+		dest:     id,
+		conn:     conn,
+		listener: globalCache,
+	}, nil
+}
+
+/*DialKCPWithoutCache Dial KCP connection
+This Dialer will ignore src this is a restriction
+due to github.com/xtaci/kcp-go.DialWithOptions
+*/
+func DialKCPWithoutCache(src v2net.Address, dest v2net.Destination) (net.Conn, error) {
+	return DialKCP(dest)
 }

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -74,6 +74,8 @@ type KCPVconn struct {
 	conntokeep time.Time
 }
 
+var counter int
+
 func (kcpvc *KCPVconn) Read(b []byte) (int, error) {
 	ifb := time.Now().Add(time.Duration(kcpvc.conf.AdvancedConfigs.ReadTimeout) * time.Second)
 	if ifb.After(kcpvc.conntokeep) {
@@ -114,12 +116,19 @@ func (kcpvc *KCPVconn) ApplyConf() error {
 	kcpvc.hc.SetMtu(kcpvc.conf.AdvancedConfigs.Mtu)
 	kcpvc.hc.SetACKNoDelay(kcpvc.conf.AdvancedConfigs.Acknodelay)
 	kcpvc.hc.SetDSCP(kcpvc.conf.AdvancedConfigs.Dscp)
+	//counter++
+	//log.Info(counter)
 	return nil
 }
 
 func (kcpvc *KCPVconn) Close() error {
-
-	return kcpvc.hc.Close()
+	go func() {
+		time.Sleep(2000 * time.Millisecond)
+		//counter--
+		//log.Info(counter)
+		kcpvc.hc.Close()
+	}()
+	return nil
 }
 
 func (kcpvc *KCPVconn) LocalAddr() net.Addr {

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -17,7 +17,7 @@ type KCPVlistener struct {
 	conf *kcpv.Config
 }
 
-func (kvl *KCPVlistener) Accept() (*KCPVconn, error) {
+func (kvl *KCPVlistener) Accept() (net.Conn, error) {
 	conn, err := kvl.lst.Accept()
 	if err != nil {
 		return nil, err

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -19,6 +19,12 @@ type KCPVlistener struct {
 	previousSocketid_mapid int
 }
 
+/*Accept Accept a KCP connection
+Since KCP is stateless, if package deliver after it was closed,
+It could be reconized as a new connection and call accept.
+If we can detect that the connection is of such a kind,
+we will discard that conn.
+*/
 func (kvl *KCPVlistener) Accept() (net.Conn, error) {
 	conn, err := kvl.lst.Accept()
 	if err != nil {
@@ -37,6 +43,7 @@ func (kvl *KCPVlistener) Accept() (net.Conn, error) {
 		}
 	}
 	if badbit {
+		conn.Close()
 		return nil, errors.New("KCP:ConnDup, Don't worry~")
 	} else {
 		kvl.previousSocketid_mapid++

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -74,7 +74,7 @@ type KCPVconn struct {
 	conntokeep time.Time
 }
 
-var counter int
+//var counter int
 
 func (kcpvc *KCPVconn) Read(b []byte) (int, error) {
 	ifb := time.Now().Add(time.Duration(kcpvc.conf.AdvancedConfigs.ReadTimeout) * time.Second)

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/v2ray/v2ray-core/common/log"
+	"github.com/v2ray/v2ray-core/transport"
 	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
 	"github.com/xtaci/kcp-go"
 )
@@ -108,4 +109,20 @@ func (kcpvc *KCPVconn) SetReadDeadline(t time.Time) error {
 
 func (kcpvc *KCPVconn) SetWriteDeadline(t time.Time) error {
 	return kcpvc.hc.SetWriteDeadline(t)
+}
+
+func DialKCP(dest v2net.Destination) (*KCPVconn, error) {
+	kcpconf := transport.KcpConfig
+	cpip, _ := kcpv.GetChipher(kcpconf.Key)
+	kcv, err := kcp.DialWithOptions(kcpconf.AdvancedConfigs.Fec, dest.NetAddr(), cpip)
+	if err != nil {
+		return nil, err
+	}
+	kcvn := &KCPVconn{hc: kcv}
+	kcvn.conf = kcpconf
+	err = kcvn.ApplyConf()
+	if err != nil {
+		return nil, err
+	}
+	return kcvn, nil
 }

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -66,9 +66,11 @@ func (kvl *KCPVlistener) Accept() (net.Conn, error) {
 	}
 	return kcv, nil
 }
+
 func (kvl *KCPVlistener) Close() error {
 	return kvl.lst.Close()
 }
+
 func (kvl *KCPVlistener) Addr() net.Addr {
 	return kvl.lst.Addr()
 }

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/v2ray/v2ray-core/common/log"
+	v2net "github.com/v2ray/v2ray-core/common/net"
 	"github.com/v2ray/v2ray-core/transport"
 	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
 	"github.com/xtaci/kcp-go"
@@ -125,4 +126,13 @@ func DialKCP(dest v2net.Destination) (*KCPVconn, error) {
 		return nil, err
 	}
 	return kcvn, nil
+}
+
+func ListenKCP(address v2net.Address, port v2net.Port) (*KCPVlistener, error) {
+	kcpconf := transport.KcpConfig
+	cpip, _ := kcpv.GetChipher(kcpconf.Key)
+	laddr := address.String() + ":" + port.String()
+	kcl, err := kcp.ListenWithOptions(kcpconf.AdvancedConfigs.Fec, laddr, cpip)
+	kcvl := &KCPVlistener{lst: kcl, conf: kcpconf}
+	return kcvl, err
 }

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -32,7 +32,6 @@ func (kvl *KCPVlistener) Accept() (net.Conn, error) {
 	var badbit bool = false
 
 	for _, key := range kvl.previousSocketid {
-		log.Info("kcp: listener testing,", key, ":", conn.GetConv())
 		if key == conn.GetConv() {
 			badbit = true
 		}

--- a/transport/hub/kcp.go
+++ b/transport/hub/kcp.go
@@ -1,0 +1,104 @@
+package hub
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/v2ray/v2ray-core/common/log"
+	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
+	"github.com/xtaci/kcp-go"
+)
+
+type KCPVlistener struct {
+	lst  *kcp.Listener
+	conf *kcpv.Config
+}
+
+func (kvl *KCPVlistener) Accept() (*KCPVconn, error) {
+	conn, err := kvl.lst.Accept()
+	if err != nil {
+		return nil, err
+	}
+	nodelay, interval, resend, nc := 0, 40, 0, 0
+	if kvl.conf.Mode != "manual" {
+		switch kvl.conf.Mode {
+		case "normal":
+			nodelay, interval, resend, nc = 0, 30, 2, 1
+		case "fast":
+			nodelay, interval, resend, nc = 0, 20, 2, 1
+		case "fast2":
+			nodelay, interval, resend, nc = 1, 20, 2, 1
+		case "fast3":
+			nodelay, interval, resend, nc = 1, 10, 2, 1
+		}
+	} else {
+		log.Error("kcp: Accepted Unsuccessfully: Manual mode is not supported.(yet!)")
+		return nil, errors.New("kcp: Manual Not Implemented")
+	}
+
+	conn.SetNoDelay(nodelay, interval, resend, nc)
+	conn.SetWindowSize(kvl.conf.AdvancedConfigs.Sndwnd, kvl.conf.AdvancedConfigs.Rcvwnd)
+	conn.SetMtu(kvl.conf.AdvancedConfigs.Mtu)
+	conn.SetACKNoDelay(kvl.conf.AdvancedConfigs.Acknodelay)
+	conn.SetDSCP(kvl.conf.AdvancedConfigs.Dscp)
+
+	kcv := &KCPVconn{hc: conn}
+	kcv.conf = kvl.conf
+	return kcv, nil
+}
+func (kvl *KCPVlistener) Close() error {
+	return kvl.lst.Close()
+}
+func (kvl *KCPVlistener) Addr() net.Addr {
+	return kvl.lst.Addr()
+}
+
+type KCPVconn struct {
+	hc         *kcp.UDPSession
+	conf       *kcpv.Config
+	conntokeep time.Time
+}
+
+func (kcpvc *KCPVconn) Read(b []byte) (int, error) {
+	ifb := time.Now().Add(time.Duration(kcpvc.conf.AdvancedConfigs.ReadTimeout) * time.Second)
+	if ifb.After(kcpvc.conntokeep) {
+		kcpvc.conntokeep = ifb
+	}
+	kcpvc.hc.SetDeadline(kcpvc.conntokeep)
+	return kcpvc.hc.Read(b)
+}
+
+func (kcpvc *KCPVconn) Write(b []byte) (int, error) {
+	ifb := time.Now().Add(time.Duration(kcpvc.conf.AdvancedConfigs.WriteTimeout) * time.Second)
+	if ifb.After(kcpvc.conntokeep) {
+		kcpvc.conntokeep = ifb
+	}
+	kcpvc.hc.SetDeadline(kcpvc.conntokeep)
+	return kcpvc.hc.Write(b)
+}
+
+func (kcpvc *KCPVconn) Close() error {
+
+	return kcpvc.hc.Close()
+}
+
+func (kcpvc *KCPVconn) LocalAddr() net.Addr {
+	return kcpvc.hc.LocalAddr()
+}
+
+func (kcpvc *KCPVconn) RemoteAddr() net.Addr {
+	return kcpvc.hc.RemoteAddr()
+}
+
+func (kcpvc *KCPVconn) SetDeadline(t time.Time) error {
+	return kcpvc.hc.SetDeadline(t)
+}
+
+func (kcpvc *KCPVconn) SetReadDeadline(t time.Time) error {
+	return kcpvc.hc.SetReadDeadline(t)
+}
+
+func (kcpvc *KCPVconn) SetWriteDeadline(t time.Time) error {
+	return kcpvc.hc.SetWriteDeadline(t)
+}

--- a/transport/hub/kcp/config.go
+++ b/transport/hub/kcp/config.go
@@ -1,0 +1,22 @@
+package kcp
+
+type AdvancedConfig struct {
+	Mtu          int  `json:"MaximumTransmissionUnit"`
+	Sndwnd       int  `json:"SendingWindowSize"`
+	Rcvwnd       int  `json:"ReceivingWindowSize"`
+	Fec          int  `json:"ForwardErrorCorrectionGroupSize"`
+	Acknodelay   bool `json:"AcknowledgeNoDelay"`
+	Dscp         int  `json:"Dscp"`
+	ReadTimeout  int  `json:"ReadTimeout"`
+	WriteTimeout int  `json:"WriteTimeout"`
+}
+
+type Config struct {
+	Mode            string          `json:"Mode"`
+	Key             string          `json:"EncryptionKey"`
+	AdvancedConfigs *AdvancedConfig `json:"AdvancedConfig,omitempty"`
+}
+
+var DefaultAdvancedConfigs = &AdvancedConfig{
+	Mtu: 1350, Sndwnd: 1024, Rcvwnd: 1024, Fec: 4, Dscp: 0, ReadTimeout: 60, WriteTimeout: 40, Acknodelay: false,
+}

--- a/transport/hub/kcp_test.go
+++ b/transport/hub/kcp_test.go
@@ -1,0 +1,31 @@
+package hub_test
+
+import "testing"
+
+import (
+	v2net "github.com/v2ray/v2ray-core/common/net"
+	"github.com/v2ray/v2ray-core/testing/assert"
+	"github.com/v2ray/v2ray-core/transport"
+	"github.com/v2ray/v2ray-core/transport/hub"
+	"github.com/v2ray/v2ray-core/transport/hub/kcpv"
+)
+
+func Test_Pair(t *testing.T) {
+	assert := assert.On(t)
+	transport.KcpConfig = &kcpv.Config{}
+	transport.KcpConfig.Mode = "fast2"
+	transport.KcpConfig.Key = "key"
+	transport.KcpConfig.AdvancedConfigs = kcpv.DefaultAdvancedConfigs
+	lst, _ := hub.ListenKCP(v2net.ParseAddress("127.0.0.1"), 17777)
+	go func() {
+		connx, err2 := lst.Accept()
+		assert.Error(err2).IsNil()
+		connx.Close()
+	}()
+	conn, _ := hub.DialKCP(v2net.TCPDestination(v2net.ParseAddress("127.0.0.1"), 17777))
+	conn.LocalAddr()
+	conn.RemoteAddr()
+	conn.ApplyConf()
+	conn.Write([]byte("x"))
+	conn.Close()
+}

--- a/transport/hub/kcpv/config.go
+++ b/transport/hub/kcpv/config.go
@@ -1,5 +1,34 @@
 package kcpv
 
+/*AdvancedConfig define behavior of KCP in detail
+
+MaximumTransmissionUnit:
+Largest protocol data unit that the layer can pass onwards
+can be discovered by running tracepath
+
+SendingWindowSize , ReceivingWindowSize:
+the size of Tx/Rx window, by packet
+
+ForwardErrorCorrectionGroupSize:
+The the size of packet to generate a Forward Error Correction
+packet, this is used to counteract packet loss.
+
+AcknowledgeNoDelay:
+Do not wait a certain of time before sending the ACK packet,
+increase bandwich cost and might increase performance
+
+Dscp:
+Differentiated services code point,
+be used to reconized to discriminate packet.
+It is recommanded to keep it 0 to avoid being detected.
+
+ReadTimeout,WriteTimeout:
+Close the Socket if it have been silent for too long,
+Small value can recycle zombie socket faster but
+can cause v2ray to kill the proxy connection it is relaying,
+Higher value can prevent server from closing zombie socket and
+waste resources.
+*/
 type AdvancedConfig struct {
 	Mtu          int  `json:"MaximumTransmissionUnit"`
 	Sndwnd       int  `json:"SendingWindowSize"`
@@ -11,6 +40,20 @@ type AdvancedConfig struct {
 	WriteTimeout int  `json:"WriteTimeout"`
 }
 
+/*Config define basic behavior of KCP
+Mode:
+can be one of these values:
+fast3,fast2,fast,normal
+<<<<<<- less delay
+->>>>>> less bandwich wasted
+
+EncryptionKey:
+a string that will be the EncryptionKey of
+All KCP connection we Listen-Accpet or
+Dial, We are not very sure about how this
+encryption hehave and DO use a unique randomly
+generated key.
+*/
 type Config struct {
 	Mode            string          `json:"Mode"`
 	Key             string          `json:"EncryptionKey"`
@@ -18,5 +61,5 @@ type Config struct {
 }
 
 var DefaultAdvancedConfigs = &AdvancedConfig{
-	Mtu: 1350, Sndwnd: 1024, Rcvwnd: 1024, Fec: 4, Dscp: 0, ReadTimeout: 18600, WriteTimeout: 18500, Acknodelay: false,
+	Mtu: 1350, Sndwnd: 1024, Rcvwnd: 1024, Fec: 4, Dscp: 0, ReadTimeout: 600, WriteTimeout: 500, Acknodelay: false,
 }

--- a/transport/hub/kcpv/config.go
+++ b/transport/hub/kcpv/config.go
@@ -18,5 +18,5 @@ type Config struct {
 }
 
 var DefaultAdvancedConfigs = &AdvancedConfig{
-	Mtu: 1350, Sndwnd: 1024, Rcvwnd: 1024, Fec: 4, Dscp: 0, ReadTimeout: 60, WriteTimeout: 40, Acknodelay: false,
+	Mtu: 1350, Sndwnd: 1024, Rcvwnd: 1024, Fec: 4, Dscp: 0, ReadTimeout: 18600, WriteTimeout: 18500, Acknodelay: false,
 }

--- a/transport/hub/kcpv/config.go
+++ b/transport/hub/kcpv/config.go
@@ -1,4 +1,4 @@
-package kcp
+package kcpv
 
 type AdvancedConfig struct {
 	Mtu          int  `json:"MaximumTransmissionUnit"`

--- a/transport/hub/kcpv/config_json.go
+++ b/transport/hub/kcpv/config_json.go
@@ -1,0 +1,1 @@
+package kcpv

--- a/transport/hub/kcpv/config_json.go
+++ b/transport/hub/kcpv/config_json.go
@@ -1,1 +1,3 @@
 package kcpv
+
+//We can use the default version of json parser

--- a/transport/hub/kcpv/crypto.go
+++ b/transport/hub/kcpv/crypto.go
@@ -1,0 +1,21 @@
+package kcpv
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+)
+
+func generateKeyFromConfigString(key string) []byte {
+	key += "consensus salt: Let's fight arcifical deceleration with our code. We shall prove our believes with action."
+	keyw := sha256.Sum256([]byte(key))
+	return keyw[:]
+}
+
+func generateBlockWithKey(key []byte) (cipher.Block, error) {
+	return aes.NewCipher(key)
+}
+
+func GetChipher(key string) (cipher.Block, error) {
+	return generateBlockWithKey(generateKeyFromConfigString(key))
+}

--- a/transport/hub/tcp.go
+++ b/transport/hub/tcp.go
@@ -92,7 +92,7 @@ func (this *TCPHub) start() {
 
 		if err != nil {
 			if this.accepting {
-				log.Info("Listener: Failed to accept new TCP connection: ", err)
+				log.Warning("Listener: Failed to accept new TCP connection: ", err)
 			}
 			continue
 		}

--- a/transport/hub/tcp.go
+++ b/transport/hub/tcp.go
@@ -92,7 +92,7 @@ func (this *TCPHub) start() {
 
 		if err != nil {
 			if this.accepting {
-				log.Warning("Listener: Failed to accept new TCP connection: ", err)
+				log.info("Listener: Failed to accept new TCP connection: ", err)
 			}
 			continue
 		}

--- a/transport/hub/tcp.go
+++ b/transport/hub/tcp.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/v2ray/v2ray-core/common/log"
 	v2net "github.com/v2ray/v2ray-core/common/net"
+	"github.com/v2ray/v2ray-core/proxy"
+	"github.com/v2ray/v2ray-core/transport"
 )
 
 var (
@@ -46,6 +48,14 @@ func ListenTCP(address v2net.Address, port v2net.Port, callback ConnectionHandle
 
 	go hub.start()
 	return hub, nil
+}
+func ListenTCP6(address v2net.Address, port v2net.Port, callback ConnectionHandler, proxyMeta proxy.InboundHandlerMeta, tlsConfig *tls.Config) (*TCPHub, error) {
+	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
+		return nil, errors.New("ListenTCP6: Not Implemented")
+	} else {
+		return ListenTCP(address, port, callback, tlsConfig)
+	}
+	return nil, errors.New("ListenTCP6: Not Implemented")
 }
 
 func (this *TCPHub) Close() {

--- a/transport/hub/tcp.go
+++ b/transport/hub/tcp.go
@@ -71,7 +71,7 @@ func ListenKCPhub(address v2net.Address, port v2net.Port, callback ConnectionHan
 	go hub.start()
 	return hub, nil
 }
-func ListenTCP6(address v2net.Address, port v2net.Port, callback ConnectionHandler, proxyMeta proxy.InboundHandlerMeta, tlsConfig *tls.Config) (*TCPHub, error) {
+func ListenTCP6(address v2net.Address, port v2net.Port, callback ConnectionHandler, proxyMeta *proxy.InboundHandlerMeta, tlsConfig *tls.Config) (*TCPHub, error) {
 	if proxyMeta.KcpSupported && transport.IsKcpEnabled() {
 		return ListenKCPhub(address, port, callback, tlsConfig)
 	} else {

--- a/transport/hub/tcp.go
+++ b/transport/hub/tcp.go
@@ -92,7 +92,7 @@ func (this *TCPHub) start() {
 
 		if err != nil {
 			if this.accepting {
-				log.info("Listener: Failed to accept new TCP connection: ", err)
+				log.Info("Listener: Failed to accept new TCP connection: ", err)
 			}
 			continue
 		}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,9 +1,17 @@
 package transport
 
+import "github.com/v2ray/v2ray-core/transport/hub/kcpv"
+
 var (
 	connectionReuse = true
+	enableKcp       = false
+	KcpConfig       *kcpv.Config
 )
 
 func IsConnectionReusable() bool {
 	return connectionReuse
+}
+
+func IsKcpEnabled() bool {
+	return enableKcp
 }


### PR DESCRIPTION
TCP连接在高延迟，高带宽，较高丢包环境下，不能有效利用带宽。目前TCP连接下的VMess协议在这种网络环境下速度缓慢，甚至出现连接超时错误。

KCP可以更加有效的利用带宽降低延迟，很大程度上减少因为恶劣的网络环境导致的连接不稳。

通过提高代理连接的速度，可以有效的改善使用v2ray的体验。

新增加了一部分API，请查看 #162 了解详情。 

需要注意的是：引入了 github.com/xtaci/kcp-go 库， 这个库的API的稳定性值得怀疑，在合并时可以考虑将该库的地址替换为V2ray可以有效控制的地址。