### PR TITLE
Fix bug not applying streamSettings/security to connection, which might introduced by migrating to protocol buffer

### DIFF
--- a/transport/internet/config.go
+++ b/transport/internet/config.go
@@ -56,11 +56,11 @@ func (v *StreamConfig) GetEffectiveSecuritySettings() (interface{}, error) {
 			return settings.GetInstance()
 		}
 	}
-	return loader.GetInstance(v.SecurityType)
+	return loader.GetInstance(v.SecuritySettings[0].Type)
 }
 
 func (v *StreamConfig) HasSecuritySettings() bool {
-	return len(v.SecurityType) > 0
+	return v.SecuritySettings != nil
 }
 
 func ApplyGlobalNetworkSettings(settings []*NetworkSettings) error {


### PR DESCRIPTION
In transport/internet/config.go:
func (v *StreamConfig) HasSecuritySettings() bool always returns false, regardless streamSettings/security's value.

This bug might have downgraded security guard for some user. As inbound and outbound can be influenced by this bug, some user might not able to discover this bug while their sensitive data transfer over network with surveillance. 