### PR TITLE
Update ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,44 +1,44 @@
 提交 Issue 之前请先阅读 [Issue 指引](https://www.v2ray.com/zh_cn/chapter_01/issue.html)，然后回答下面的问题，谢谢。
 Please read the [instruction](https://www.v2ray.com/en/get_started/issue.html) and answer the following questions before submitting your issue. Thank you.
 
-1)  你正在使用哪个版本的 V2Ray？（如果服务器和客户端使用了不同版本，请注明）
+1. 你正在使用哪个版本的 V2Ray？（如果服务器和客户端使用了不同版本，请注明）
     What version of V2Ray are you using (If you deploy different version on server and client, please explicitly point out)?
 
-2)  你的使用场景是什么？比如使用 Chrome 通过 Socks/VMess 代理观看 YouTube 视频。
+2. 你的使用场景是什么？比如使用 Chrome 通过 Socks/VMess 代理观看 YouTube 视频。
     What's your scenario of using V2Ray? E.g., Watching YouTube videos in Chrome via Socks/VMess proxy.
 
-3)  你看到的不正常的现象是什么？
+3. 你看到的不正常的现象是什么？
     What did you see?
 
-4)  你期待看到的正确表现是怎样的？
+4. 你期待看到的正确表现是怎样的？
     What's your expectation?
 
-5)  请附上你的配置文件（提交 Issue 前请隐藏服务器端IP地址）。
+5. 请附上你的配置文件（**提交 Issue 前请隐藏服务器端IP地址**）。
     Please attach your configuration file (**Mask IP addresses before submit this issue**).
 
     Server Configuration File（服务器端配置文件）:
     ```javascript
-    // 在这里附上服务器端配置文件
+    // 请把这行文字替换成服务器端配置文件
     // Please attach your server configuration file here.
     ```
-    
+
     Client Configuration File（客户端配置文件）:
     ```javascript
-    // 在这里附上客户端配置文件
+    // 请把这行文字替换成客户端配置文件
     // Please attach your client configuration file here.
     ```
-    
-6)  请附上出错时软件输出的日志。在 Linux 中，日志通常在 `/var/log/v2ray/error.log` 文件中。
+
+6. 请附上出错时软件输出的日志。在 Linux 中，日志通常在 `/var/log/v2ray/error.log` 文件中。
     Please attach the log file, especially the bottom lines if the file is large. Log file is usually `/var/log/v2ray/error.log` on Linux.
 
     Server Log File（服务器端日志）:
     ```
-    // 在这里附上服务器端日志
+    // 请把这行文字替换成服务器端日志
     // Please attach your server log here.
     ```
     
     Client Log File（客户端日志）:
     ```
-    // 在这里附上客户端日志
+    // 请把这行文字替换成客户端日志
     // Please attach your client log here.
     ```


### PR DESCRIPTION
* 将 "在这里附上服务器端配置文件" 之类的话语改成 "请把这行文字替换成服务器端配置文件"，避免一些不会 Markdown 语法的人将配置文件、日志什么的贴在错误的地方 由此导致无法在 GitHub Issue 里的文字排版问题。
* 将 "1)  2)" 之类的改为 Markdown 的有序列表语法
* 删除2个不必要的 "4-space tab"