### PR TITLE
Reserve protobuf tag for libv2ray

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -31,4 +31,9 @@ message Config {
 
   // Transport settings.
   v2ray.core.transport.Config transport = 5;
+
+  //Reserved for LibV2Ray Client
+  //Content of this section can be ignored by v2ray-core
+  reserved 12;
+  reserved "#libv2ray";
 }


### PR DESCRIPTION
Reserve tag for libv2ray, so that libv2ray and v2ray-core can share the same configure file.