### PR TITLE
fix HTTP proxy OK response

### DIFF
--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -122,7 +122,7 @@ Start:
 }
 
 func (s *Server) handleConnect(ctx context.Context, request *http.Request, reader io.Reader, writer io.Writer, dest v2net.Destination, dispatcher dispatcher.Interface) error {
-	_, err := writer.Write([]byte("HTTP/1.1 200 Connection established\n\n"))
+	_, err := writer.Write([]byte("HTTP/1.1 200 Connection established\r\n\r\n"))
 	if err != nil {
 		return newError("failed to write back OK response").Base(err)
 	}


### PR DESCRIPTION
According to [RFC 2616](https://tools.ietf.org/html/rfc2616#section-2.2)
```plain
HTTP/1.1 defines the sequence CR LF as the end-of-line marker for all
protocol elements except the entity-body (see appendix 19.3 for
tolerant applications).
```