### PR TITLE
fix timer leak

### DIFF
--- a/common/signal/timer.go
+++ b/common/signal/timer.go
@@ -29,7 +29,9 @@ func (t *ActivityTimer) SetTimeout(timeout time.Duration) {
 
 func (t *ActivityTimer) run() {
 	ticker := time.NewTicker(<-t.timeout)
-	defer ticker.Stop()
+	defer func() {
+		ticker.Stop()
+	}()
 
 	for {
 		select {


### PR DESCRIPTION
The following code leads to timer leak. `defer ticker.Stop()` cannot stop the new ticker because of different addresses. The patch fixes this bug.
```
case timeout := <-t.timeout:
 			ticker.Stop()
 			ticker = time.NewTicker(timeout)
```