### PR TITLE
Vmess: Use aes-128-gcm by default on arm64 platform

### DIFF
--- a/common/protocol/headers.go
+++ b/common/protocol/headers.go
@@ -87,7 +87,7 @@ type CommandSwitchAccount struct {
 
 func (sc *SecurityConfig) AsSecurity() Security {
 	if sc == nil || sc.Type == SecurityType_AUTO {
-		if runtime.GOARCH == "amd64" || runtime.GOARCH == "s390x" {
+		if runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64" || runtime.GOARCH == "s390x" {
 			return Security(SecurityType_AES128_GCM)
 		}
 		return Security(SecurityType_CHACHA20_POLY1305)


### PR DESCRIPTION
AES instructions are available on most arm64 phones since ARMv8-A. Modern browsers like Chrome also prefers aes-128-gcm on arm64 platform, leaving chacha20-poly1305 preferred only on 32-bit arm platform.

Speed test on Snapdragon 821 (MSM8996AB Pro):
```
# openssl speed -elapsed -evp chacha20-poly1305
You have chosen to measure elapsed time instead of user CPU time.
Doing chacha20-poly1305 for 3s on 16 size blocks: 12813542 chacha20-poly1305's in 3.00s
Doing chacha20-poly1305 for 3s on 64 size blocks: 7206714 chacha20-poly1305's in 3.00s
Doing chacha20-poly1305 for 3s on 256 size blocks: 2782860 chacha20-poly1305's in 3.00s
Doing chacha20-poly1305 for 3s on 1024 size blocks: 762759 chacha20-poly1305's in 3.00s
Doing chacha20-poly1305 for 3s on 8192 size blocks: 97398 chacha20-poly1305's in 3.00s
Doing chacha20-poly1305 for 3s on 16384 size blocks: 48783 chacha20-poly1305's in 3.00s
OpenSSL 1.1.0f  25 May 2017
built on: reproducible build, date unspecified
options:bn(64,32) rc4(char) des(long) aes(partial) blowfish(ptr)
compiler: gcc -DDSO_DLFCN -DHAVE_DLFCN_H -DNDEBUG -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/lib/ssl\"" -DENGINESDIR="\"/usr/lib/arm-linux-gnueabihf/engines-1.1\""
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
chacha20-poly1305    68338.89k   153743.23k   237470.72k   260355.07k   265961.47k   266420.22k

# openssl speed -elapsed -evp aes-128-gcm
You have chosen to measure elapsed time instead of user CPU time.
Doing aes-128-gcm for 3s on 16 size blocks: 21963425 aes-128-gcm's in 3.00s
Doing aes-128-gcm for 3s on 64 size blocks: 14156835 aes-128-gcm's in 3.00s
Doing aes-128-gcm for 3s on 256 size blocks: 6218991 aes-128-gcm's in 3.00s
Doing aes-128-gcm for 3s on 1024 size blocks: 1874332 aes-128-gcm's in 3.00s
Doing aes-128-gcm for 3s on 8192 size blocks: 247873 aes-128-gcm's in 3.00s
Doing aes-128-gcm for 3s on 16384 size blocks: 122891 aes-128-gcm's in 3.00s
OpenSSL 1.1.0f  25 May 2017
built on: reproducible build, date unspecified
options:bn(64,32) rc4(char) des(long) aes(partial) blowfish(ptr)
compiler: gcc -DDSO_DLFCN -DHAVE_DLFCN_H -DNDEBUG -DOPENSSL_THREADS -DOPENSSL_NO_STATIC_ENGINE -DOPENSSL_PIC -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DAES_ASM -DBSAES_ASM -DGHASH_ASM -DECP_NISTZ256_ASM -DPOLY1305_ASM -DOPENSSLDIR="\"/usr/lib/ssl\"" -DENGINESDIR="\"/usr/lib/arm-linux-gnueabihf/engines-1.1\""
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
aes-128-gcm     117138.27k   302012.48k   530687.23k   639771.99k   676858.54k   671148.71k
```

PS. Maybe we should let the go runtime check CPU instructions sets rather than CPU architectures when choosing default cipher. On many old amd64 CPUs without AES-NI, chacha20-poly1305 is also way faster than aes-128-gcm.