### PR TITLE
Fix nit errors

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -55,12 +55,12 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 	ctx = proxy.ContextWithTarget(ctx, destination)
 
 	outbound := ray.NewRay(ctx)
-	sniferList := proxyman.ProtocoSniffersFromContext(ctx)
-	if destination.Address.Family().IsDomain() || len(sniferList) == 0 {
+	snifferList := proxyman.ProtocoSniffersFromContext(ctx)
+	if destination.Address.Family().IsDomain() || len(snifferList) == 0 {
 		go d.routedDispatch(ctx, outbound, destination)
 	} else {
 		go func() {
-			domain, err := snifer(ctx, sniferList, outbound)
+			domain, err := sniffer(ctx, snifferList, outbound)
 			if err == nil {
 				newError("sniffed domain: ", domain).WithContext(ctx).WriteToLog()
 				destination.Address = net.ParseAddress(domain)
@@ -72,11 +72,11 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 	return outbound, nil
 }
 
-func snifer(ctx context.Context, sniferList []proxyman.KnownProtocols, outbound ray.OutboundRay) (string, error) {
+func sniffer(ctx context.Context, snifferList []proxyman.KnownProtocols, outbound ray.OutboundRay) (string, error) {
 	payload := buf.New()
 	defer payload.Release()
 
-	sniffer := NewSniffer(sniferList)
+	sniffer := NewSniffer(snifferList)
 	totalAttempt := 0
 	for {
 		select {

--- a/app/dispatcher/sniffer.go
+++ b/app/dispatcher/sniffer.go
@@ -173,10 +173,10 @@ type Sniffer struct {
 	err   []error
 }
 
-func NewSniffer(sniferList []proxyman.KnownProtocols) *Sniffer {
+func NewSniffer(snifferList []proxyman.KnownProtocols) *Sniffer {
 	s := new(Sniffer)
 
-	for _, protocol := range sniferList {
+	for _, protocol := range snifferList {
 		var f func([]byte) (string, error)
 		switch protocol {
 		case proxyman.KnownProtocols_HTTP:

--- a/common/dice/dice.go
+++ b/common/dice/dice.go
@@ -9,9 +9,6 @@ import (
 
 // Roll returns a non-negative number between 0 (inclusive) and n (exclusive).
 func Roll(n int) int {
-	if n == 1 {
-		return 0
-	}
 	return rand.Intn(n)
 }
 

--- a/proxy/vmess/vmess.go
+++ b/proxy/vmess/vmess.go
@@ -159,7 +159,7 @@ func (v *TimedUserValidator) Remove(email string) bool {
 		return false
 	}
 	ulen := len(v.users)
-	if idx < len(v.users) {
+	if idx < ulen {
 		v.users[idx] = v.users[ulen-1]
 		v.users[ulen-1] = nil
 		v.users = v.users[:ulen-1]

--- a/v2ray.go
+++ b/v2ray.go
@@ -124,7 +124,7 @@ func (s *Instance) Start() error {
 		}
 	}
 
-	newError("V2Ray started").AtWarning().WriteToLog()
+	newError("V2Ray started").AtInfo().WriteToLog()
 
 	return nil
 }


### PR DESCRIPTION
1. Fix snifer -> sniffer typo
2. Remove duplicate len function call
3. System rand.Intn(1) will always return 0, so we can return directly.
4. Info when v2ray started is more reasonable than warning.