### PR TITLE
Capture command error output

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -206,7 +206,7 @@ startV2ray(){
 copyFile() {
     NAME=$1
     MANDATE=$2
-    ERROR=`cp "/tmp/v2ray/v2ray-${NEW_VER}-linux-${VDIS}/${NAME}" "/usr/bin/v2ray/${NAME}"`
+    ERROR=`cp "/tmp/v2ray/v2ray-${NEW_VER}-linux-${VDIS}/${NAME}" "/usr/bin/v2ray/${NAME}" 2>&1`
     if [[ $? -ne 0 ]]; then
         colorEcho ${YELLOW} "${ERROR}"
         if [ "$MANDATE" = true ]; then


### PR DESCRIPTION
```
➜  a git:(master) ✗ ERROR=`cp c d`
cp: c: No such file or directory
➜  a git:(master) ✗ echo $?
1
➜  a git:(master) ✗ echo $ERROR

➜  a git:(master) ✗ ERROR=`cp c d 2>&1`
➜  a git:(master) ✗ echo $?
1
➜  a git:(master) ✗ echo $ERROR
cp: c: No such file or directory
```
According above test suggests ERROR is always EMPTY string if we don't capture command error output