### PR TITLE
consistent  ServerSpec  variable name

### DIFF
--- a/common/protocol/server_spec.go
+++ b/common/protocol/server_spec.go
@@ -110,10 +110,10 @@ func (s *ServerSpec) PickUser() *User {
 	}
 }
 
-func (v *ServerSpec) IsValid() bool {
-	return v.valid.IsValid()
+func (s *ServerSpec) IsValid() bool {
+	return s.valid.IsValid()
 }
 
-func (v *ServerSpec) Invalidate() {
-	v.valid.Invalidate()
+func (s *ServerSpec) Invalidate() {
+	s.valid.Invalidate()
 }


### PR DESCRIPTION
在前面的方法中, 都使用了 s 作为变量,  这里虽然实现了  ValidateStrategy interface,  从代码的一致性上看还是 继续用  s  比较合理. 