### PR TITLE
fix a test failure on windows

### DIFF
--- a/common/platform/platform_test.go
+++ b/common/platform/platform_test.go
@@ -3,6 +3,7 @@ package platform_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "v2ray.com/core/common/platform"
@@ -52,7 +53,11 @@ func TestGetAssetLocation(t *testing.T) {
 	assert(filepath.Dir(loc), Equals, filepath.Dir(exec))
 
 	os.Setenv("v2ray.location.asset", "/v2ray")
-	assert(GetAssetLocation("t"), Equals, "/v2ray/t")
+	if runtime.GOOS == "windows" {
+		assert(GetAssetLocation("t"), Equals, "\\v2ray\\t")
+	} else {
+		assert(GetAssetLocation("t"), Equals, "/v2ray/t")
+	}
 }
 
 func TestGetPluginLocation(t *testing.T) {


### PR DESCRIPTION
reproduced on  go1.10 windows/amd64  version : https://github.com/v2ray/v2ray-core/commit/3c2b75f548e36959296b8069a062070c915e9f83

platform_test.go:55: Not true that (\v2ray\t) equals to (/v2ray/t)
--- FAIL: TestGetAssetLocation (0.00s)
