### PR TITLE
read rest of buffer when any errors

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -82,12 +82,10 @@ func (h *Handler) Dispatch(ctx context.Context, link *core.Link) {
 		}
 	} else {
 		if err := h.proxy.Process(ctx, link, h); err != nil {
-			// Ensure outbound ray is properly closed.
 			newError("failed to process outbound traffic").Base(err).WithContext(ctx).WriteToLog()
-			pipe.CloseError(link.Writer)
-		} else {
-			common.Must(common.Close(link.Writer))
 		}
+		// read the rest of buffer when any errors
+		common.Must(common.Close(link.Writer))
 		pipe.CloseError(link.Reader)
 	}
 }


### PR DESCRIPTION
当outbound遇到错误时，close pipe, 这样可以使pipe里面的数据读取完。如果直接closeerror的话，会清空整个pipe里面的内容，这样有点不太合理。标准库里面的read接口也是读取了多少数据就输出多少。fix #1082 