### PR TITLE
install-release.sh检查更新时忽略小版本号

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -193,7 +193,7 @@ getVersion(){
     else
         VER=`/usr/bin/v2ray/v2ray -version 2>/dev/null`
         RETVAL="$?"
-        CUR_VER=`echo $VER | head -n 1 | cut -d " " -f2`
+        CUR_VER=`echo $VER | head -n 1 | cut -d " " -f2 | cut -d. -f-2`
         TAG_URL="https://api.github.com/repos/v2ray/v2ray-core/releases/latest"
         NEW_VER=`curl ${PROXY} -s ${TAG_URL} --connect-timeout 10| grep 'tag_name' | cut -d\" -f4`
         if [[ $? -ne 0 ]] || [[ $NEW_VER == "" ]]; then


### PR DESCRIPTION
现在的版本号，如果是Pre-release的话，都会在主版本号后再加一个小版本号。但是在检查更新时，所有的Pre-release版本都会被认为不是最新的版本，导致更新回最新的大版本。
这个改动就截取当前运行版本的版本号前2个位置，所以只要运行的Pre-release版本是最新大版本系列下的，就能通过最新版本的检测。
由于Pre-release一般存在时间也不会太长，这个改动有没有必要，还请作者来定夺。