### PR TITLE
Update install-release.sh

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -197,7 +197,7 @@ getVersion(){
     else
         VER=`/usr/bin/v2ray/v2ray -version 2>/dev/null`
         RETVAL="$?"
-        CUR_VER=`echo $VER | head -n 1 | cut -d " " -f2 | cut -d. -f-2`
+        CUR_VER=`echo $VER | head -n 1 | cut -d " " -f2`
         if [[ ${CUR_VER} != v* ]]; then
             CUR_VER=v${CUR_VER}
         fi
@@ -211,7 +211,7 @@ getVersion(){
             return 3
         elif [[ $RETVAL -ne 0 ]];then
             return 2
-        elif [[ "$NEW_VER" != "$CUR_VER" ]];then
+        elif [[ `echo $NEW_VER | cut -d. -f-2` != `echo $CUR_VER | cut -d. -f-2` ]];then
             return 1
         fi
         return 0


### PR DESCRIPTION
由于新的稳定版本在版本末尾加.0了，所以检查更新的逻辑需要修改了
改成不更改根据命令获得的CUR_VER和NEW_VER参数值，直接在比对的时候截取这两个参数的前2位版本号。