### PR TITLE
Update plugin loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 bazel-*
+/build.log

--- a/main/targets.bzl
+++ b/main/targets.bzl
@@ -1,11 +1,17 @@
 load("@v2ray_ext//bazel:build.bzl", "foreign_go_binary")
 load("@v2ray_ext//bazel:gpg.bzl", "gpg_sign")
+load("@v2ray_ext//bazel:plugin.bzl", "PLUGIN_SUPPORTED_OS")
 
 def gen_targets(matrix):
   pkg = "v2ray.com/core/main"
   output = "v2ray"
 
   for (os, arch) in matrix:
+
+    cgo_enabled = "0"
+    if os in PLUGIN_SUPPORTED_OS:
+      cgo_enabled = "1"
+
     bin_name = "v2ray_" + os + "_" + arch
     foreign_go_binary(
       name = bin_name,
@@ -13,6 +19,7 @@ def gen_targets(matrix):
       output = output,
       os = os,
       arch = arch,
+      cgo_enabled = cgo_enabled,
     )
 
     gpg_sign(

--- a/plugin_dlopen.go
+++ b/plugin_dlopen.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,cgo darwin,cgo
 
 package core
 
@@ -35,9 +35,11 @@ func loadPluginsInternal() error {
 			if err != nil {
 				return err
 			}
-			if gmf, ok := f.(GetMetadataFunc); ok {
-				metadata := gmf()
+			if gmf, ok := f.(func() PluginMetadata); ok {
+				metadata := GetMetadataFunc(gmf)()
 				newError("plugin (", metadata.Name, ") loaded.").WriteToLog()
+			} else {
+				return newError(file.Name(), " is not a valid plugin.")
 			}
 		}
 	}

--- a/plugin_stubs.go
+++ b/plugin_stubs.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!darwin !cgo
 
 package core
 


### PR DESCRIPTION
### Fix plugin loader

 After loading the plugin, the type of the symbol is `func () PluginMetadata`, not `GetMetadataFunc`
https://github.com/v2ray/v2ray-core/blob/d649de172e671ee06288b98b2d2c2b5e9af4bbc8/plugin_linux.go#L38-L41


### Plugin is able to run on macOS
According to [plugin package docs](https://golang.org/pkg/plugin/#pkg-overview)
> Currently plugins are only supported on Linux and macOS. Please report any issues.