### PR TITLE
Fixed a potential error

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -211,7 +211,7 @@ getVersion(){
             return 3
         elif [[ $RETVAL -ne 0 ]];then
             return 2
-        elif [[ `echo $NEW_VER | cut -d. -f-2` != `echo $CUR_VER | cut -d. -f-2` ]];then
+        elif [[ `echo $NEW_VER | cut -d. -f1,2` != `echo $CUR_VER | cut -d. -f1,2` ]];then
             return 1
         fi
         return 0


### PR DESCRIPTION
While updating, the scrip only compare the second version number. If my local veresion is `3.1.0`, and the latest version is `4.1.0`, the script will treated it in the same way, and will not upgrade.