### PR TITLE
Update vpoint_socks_vmess.json

### DIFF
--- a/release/config/vpoint_socks_vmess.json
+++ b/release/config/vpoint_socks_vmess.json
@@ -13,9 +13,21 @@
     }
   }],
   "outbounds": [{
-    "protocol": "freedom",
-    "settings": {},
-    "tag": "direct"
+    "protocol": "vmess",
+    "settings": {
+      "vnext": [
+        {
+          "address": "v2ray.cool",
+          "port": 10086,
+          "users": [
+            {
+              "id": "23ad6b10-8d1a-40f7-8ad0-e3e35cd38297",
+              "alterId": 64
+            }
+          ]
+        }
+      ]
+    }
   }],
   "policy": {
     "levels": {


### PR DESCRIPTION
outbound 不知道什么时候变成了 freedom，于是改成了 vmess。