### PR TITLE
Fix UDP issue in Dokodemo TPROXY mode

### DIFF
--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -70,6 +70,11 @@ func applyOutboundSocketOptions(network string, address string, fd uintptr, conf
 }
 
 func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig) error {
+	if config.Mark != 0 {
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, int(config.Mark)); err != nil {
+			return newError("failed to set SO_MARK").Base(err)
+		}
+	}
 	if isTCPSocket(network) {
 		switch config.Tfo {
 		case SocketConfig_Enable:


### PR DESCRIPTION
Related: #1432 

Currently Dokodemo TPROXY mode has following issues when handling UDP traffic:

1. A new socket is created inside Dokodemo to send data back to client, this socket is bound to exact address pair of the connection. Due to inner workings of TPROXY, all packets sent from client will be intercepted by this socket and get lost.
2. Because all data is redirected to the new socket, `udpWorker` won't get any data to trigger timer update, all UDP connections will be GCed after some time regardless of whether there is any traffic.
3. If `freedom` is used as outbound, SO_MARK is not applied to the packets which causes routing loop.

This pull request fixes 1 and 3. Issue 2 requires quite a few changes to the architecture and I am not sure what is the best way to fix it, would be great if I can get some hints. :)