### PR TITLE
Update v2ray.service

### DIFF
--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -10,7 +10,7 @@ Wants=network.target
 # User=v2ray
 # Group=v2ray
 Type=simple
-PIDFile=/var/run/v2ray.pid
+PIDFile=/run/v2ray.pid
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
 # Don't restart in the case of configuration error


### PR DESCRIPTION
在新版本的systemd（240）里面，在systemctl daemon-reload后（或者安装某些新程序或者更新后），会在syslog内出现这样的日志：
systemd[1]: /etc/systemd/system/v2ray.service:7: PIDFile= references path below legacy directory /var/run/, updating /var/run/v2ray.pid → /run/v2ray.pid; please update the unit file accordingly.

实际并不影响运行，但是，在FHS 3.0（2015年发布）之后，/var/run已经被/run所替代，使用/var/run主要是提供了对老版本兼容考虑，目前多数系统都会提供一个/var/run的symbolic link指向/run

参考：https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard

我是基于即将发布Debian Buster测试发现的，目前稳定版Stretch使用的是systemd（232）并未出现这种提示。我也没在其他系统上测试过。