### PR TITLE
access log add detour tag

### DIFF
--- a/common/log/access.go
+++ b/common/log/access.go
@@ -18,6 +18,25 @@ type AccessMessage struct {
 	To     interface{}
 	Status AccessStatus
 	Reason interface{}
+	Detour interface{}
+}
+
+// AccessMessageChan access log channel
+var AccessMessageChan = make(chan AccessMessage, 100)
+
+// AccessMessageChanChecker if AccessMessageChan full, cleanup
+func AccessMessageChanChecker() {
+	if (len(AccessMessageChan) > 50) {
+		Loop:
+		for {
+			select {
+			case <-AccessMessageChan:
+			default:
+				break Loop
+			}
+		}
+		//println("cleanup AccessMessageChan", len(AccessMessageChan))
+	}
 }
 
 func (m *AccessMessage) String() string {
@@ -27,6 +46,8 @@ func (m *AccessMessage) String() string {
 	builder.WriteString(string(m.Status))
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.To))
+	builder.WriteByte(' ')
+	builder.WriteString(serial.ToString(m.Detour))
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.Reason))
 	return builder.String()

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -131,11 +131,12 @@ Start:
 	if err != nil {
 		return newError("malformed proxy host: ", host).AtWarning().Base(err)
 	}
-	log.Record(&log.AccessMessage{
+	log.AccessMessageChan <- log.AccessMessage{
 		From:   conn.RemoteAddr(),
 		To:     request.URL,
 		Status: log.AccessAccepted,
-	})
+		Reason: "",
+	}
 
 	if strings.ToUpper(request.Method) == "CONNECT" {
 		return s.handleConnect(ctx, request, reader, conn, dest, dispatcher)

--- a/proxy/shadowsocks/server.go
+++ b/proxy/shadowsocks/server.go
@@ -175,12 +175,12 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 	inbound.User = s.user
 
 	dest := request.Destination()
-	log.Record(&log.AccessMessage{
+	log.AccessMessageChan <- log.AccessMessage{
 		From:   conn.RemoteAddr(),
 		To:     dest,
 		Status: log.AccessAccepted,
 		Reason: "",
-	})
+	}
 	newError("tunnelling request to ", dest).WriteToLog(session.ExportIDToError(ctx))
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -117,12 +117,12 @@ func (s *Server) processTCP(ctx context.Context, conn internet.Connection, dispa
 		dest := request.Destination()
 		newError("TCP Connect request to ", dest).WriteToLog(session.ExportIDToError(ctx))
 		if inbound != nil && inbound.Source.IsValid() {
-			log.Record(&log.AccessMessage{
+			log.AccessMessageChan <- log.AccessMessage{
 				From:   inbound.Source,
 				To:     dest,
 				Status: log.AccessAccepted,
 				Reason: "",
-			})
+			}
 		}
 
 		return s.transport(ctx, reader, conn, dest, dispatcher)

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -250,12 +250,12 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 	}
 
 	if request.Command != protocol.RequestCommandMux {
-		log.Record(&log.AccessMessage{
+		log.AccessMessageChan <- log.AccessMessage{
 			From:   connection.RemoteAddr(),
 			To:     request.Destination(),
 			Status: log.AccessAccepted,
 			Reason: "",
-		})
+		}
 	}
 
 	newError("received request for ", request.Destination()).WriteToLog(session.ExportIDToError(ctx))


### PR DESCRIPTION
for #1639 

建了个全局的 chan AccessMessageChan
替换原先的 `log.Record(&log.AccessMessage`, 改成把`AccessMessage`放到`chan`里, 在`routedDispatch`里面加上`detourTag`后打印.

有几个位置没替换:
1> error 的打印
2> udp连接 的打印(看代码udp 连接后面没跑routedDispatch? 不是很确定 就没修改)
3>mux/server.go 里面的打印(不知道这个是做什么的, 不确定会不会跑routedDispatch)


效果
```
2019/06/06 14:55:52 tcp:127.0.0.1:4187 accepted tcp:www.google.com:443 [proxy]
2019/06/06 14:55:54 tcp:127.0.0.1:4190 accepted tcp:www.baidu.com:443 [direct]
2019/06/06 14:55:55 tcp:127.0.0.1:4195 rejected    v2ray.com/core/proxy/socks: failed to read request > read tcp 127.0.0.1:1080->127.0.0.1:4195: wsarecv: An established connection was aborted by the software in your host machine.
```