### PR TITLE
Add email into access log for shadowsocks and vmess

### DIFF
--- a/common/log/access.go
+++ b/common/log/access.go
@@ -18,10 +18,15 @@ type AccessMessage struct {
 	To     interface{}
 	Status AccessStatus
 	Reason interface{}
+	Email	 string
 }
 
 func (m *AccessMessage) String() string {
 	builder := strings.Builder{}
+	if len(m.Email) > 0 {
+		builder.WriteString(m.Email)
+		builder.WriteByte(' ')
+	}
 	builder.WriteString(serial.ToString(m.From))
 	builder.WriteByte(' ')
 	builder.WriteString(string(m.Status))

--- a/proxy/shadowsocks/server.go
+++ b/proxy/shadowsocks/server.go
@@ -114,6 +114,7 @@ func (s *Server) handlerUDPPayload(ctx context.Context, conn internet.Connection
 						To:     "",
 						Status: log.AccessRejected,
 						Reason: err,
+						Email:  request.User.Email,
 					})
 				}
 				payload.Release()
@@ -139,6 +140,7 @@ func (s *Server) handlerUDPPayload(ctx context.Context, conn internet.Connection
 					To:     dest,
 					Status: log.AccessAccepted,
 					Reason: "",
+					Email:  request.User.Email,
 				})
 			}
 			newError("tunnelling request to ", dest).WriteToLog(session.ExportIDToError(ctx))
@@ -163,6 +165,7 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 			To:     "",
 			Status: log.AccessRejected,
 			Reason: err,
+			Email:  request.User.Email,
 		})
 		return newError("failed to create request from: ", conn.RemoteAddr()).Base(err)
 	}
@@ -180,6 +183,7 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 		To:     dest,
 		Status: log.AccessAccepted,
 		Reason: "",
+		Email:  request.User.Email,
 	})
 	newError("tunnelling request to ", dest).WriteToLog(session.ExportIDToError(ctx))
 

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -233,6 +233,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 				To:     "",
 				Status: log.AccessRejected,
 				Reason: err,
+				Email: request.User.Email,
 			})
 			err = newError("invalid request from ", connection.RemoteAddr()).Base(err).AtInfo()
 		}
@@ -245,6 +246,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			To:     "",
 			Status: log.AccessRejected,
 			Reason: "Insecure encryption",
+			Email: request.User.Email,
 		})
 		return newError("client is using insecure encryption: ", request.Security)
 	}
@@ -255,6 +257,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			To:     request.Destination(),
 			Status: log.AccessAccepted,
 			Reason: "",
+			Email: request.User.Email,
 		})
 	}
 


### PR DESCRIPTION
给 shadowsocks 和 vmess 的 access log 里添加了 email 字段，效果如下，如果没有设置 email，则不会显示。
![image](https://user-images.githubusercontent.com/5820275/59733796-afd63b80-9281-11e9-8f7a-183f7d5ac1ac.png)
