### PR TITLE
Add email into access log for shadowsocks and vmess

### DIFF
--- a/common/log/access.go
+++ b/common/log/access.go
@@ -18,6 +18,7 @@ type AccessMessage struct {
 	To     interface{}
 	Status AccessStatus
 	Reason interface{}
+	Email  string
 }
 
 func (m *AccessMessage) String() string {
@@ -29,5 +30,11 @@ func (m *AccessMessage) String() string {
 	builder.WriteString(serial.ToString(m.To))
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.Reason))
+
+	if len(m.Email) > 0 {
+		builder.WriteString("email:")
+		builder.WriteString(m.Email)
+		builder.WriteByte(' ')
+	}
 	return builder.String()
 }

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -118,6 +118,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 		}
 		if inbound := session.InboundFromContext(ctx); inbound != nil && inbound.Source.IsValid() {
 			msg.From = inbound.Source
+			msg.Email = inbound.User.Email
 		}
 		log.Record(msg)
 	}

--- a/proxy/shadowsocks/server.go
+++ b/proxy/shadowsocks/server.go
@@ -139,6 +139,7 @@ func (s *Server) handlerUDPPayload(ctx context.Context, conn internet.Connection
 					To:     dest,
 					Status: log.AccessAccepted,
 					Reason: "",
+					Email:  request.User.Email,
 				})
 			}
 			newError("tunnelling request to ", dest).WriteToLog(session.ExportIDToError(ctx))
@@ -163,6 +164,7 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 			To:     "",
 			Status: log.AccessRejected,
 			Reason: err,
+			Email:  request.User.Email,
 		})
 		return newError("failed to create request from: ", conn.RemoteAddr()).Base(err)
 	}
@@ -180,6 +182,7 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 		To:     dest,
 		Status: log.AccessAccepted,
 		Reason: "",
+		Email:  request.User.Email,
 	})
 	newError("tunnelling request to ", dest).WriteToLog(session.ExportIDToError(ctx))
 

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -225,7 +225,6 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 	reader := &buf.BufferedReader{Reader: buf.NewReader(connection)}
 	svrSession := encoding.NewServerSession(h.clients, h.sessionHistory)
 	request, err := svrSession.DecodeRequestHeader(reader)
-
 	if err != nil {
 		if errors.Cause(err) != io.EOF {
 			log.Record(&log.AccessMessage{
@@ -245,6 +244,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			To:     "",
 			Status: log.AccessRejected,
 			Reason: "Insecure encryption",
+			Email:  request.User.Email,
 		})
 		return newError("client is using insecure encryption: ", request.Security)
 	}
@@ -255,6 +255,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 			To:     request.Destination(),
 			Status: log.AccessAccepted,
 			Reason: "",
+			Email:  request.User.Email,
 		})
 	}
 


### PR DESCRIPTION
给 shadowsocks 和 vmess 的 access log 里添加了 email 字段，效果如下，如果没有设置 email，则不会显示。
mux模式暂时也无法显示。
![image](https://user-images.githubusercontent.com/5820275/59733796-afd63b80-9281-11e9-8f7a-183f7d5ac1ac.png)
