### PR TITLE
fix segment fault when use api remote config

### DIFF
--- a/app/proxyman/outbound/outbound.go
+++ b/app/proxyman/outbound/outbound.go
@@ -130,7 +130,7 @@ func (m *Manager) RemoveHandler(ctx context.Context, tag string) error {
 	defer m.access.Unlock()
 
 	delete(m.taggedHandler, tag)
-	if m.defaultHandler.Tag() == tag {
+	if m.defaultHandler != nil && m.defaultHandler.Tag() == tag {
 		m.defaultHandler = nil
 	}
 


### PR DESCRIPTION
复现配置文件，只要包含 `api` 就会有问题。

```json
{
  "api": {
    "tag": "api",
    "services": [
      "HandlerService",
      "LoggerService",
      "StatsService"
    ]
  }
}
```

```
 $  docker-compose up
Creating network "v2ray-controller_default" with the default driver
Creating v2ray ... done
Attaching to v2ray
v2ray    | V2Ray 4.19.1 (Let's Fly) Custom
v2ray    | A unified platform for anti-censorship.
v2ray    | panic: runtime error: invalid memory address or nil pointer dereference
v2ray    | [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x800900]
v2ray    |
v2ray    | goroutine 1 [running]:
v2ray    | v2ray.com/core/app/proxyman/outbound.(*Manager).RemoveHandler(0xc0000aafa0, 0xd99b40, 0xc000036018, 0xc000036a40, 0x3, 0x0, 0x0)
v2ray    | 	v2ray.com/core/app/proxyman/outbound/outbound.go:133 +0xb0
v2ray    | v2ray.com/core/app/commander.(*Commander).Start(0xc0000ab2c0, 0x0, 0x0)
v2ray    | 	v2ray.com/core/app/commander/commander.go:83 +0x204
v2ray    | v2ray.com/core.(*Instance).Start(0xc00006a880, 0x0, 0x0)
v2ray    | 	v2ray.com/core/v2ray.go:316 +0xac
v2ray    | main.main()
v2ray    | 	v2ray.com/core/main/main.go:110 +0xe0
```

Docker 的版本可能有点旧，我依依不舍地测试了最新版本还是有这个问题，然后我又依依不舍去找古老的版本，发现一年多两年前都又问题。（怎么感觉不大对，这个世界上就只有我想用 API 嘛？）

除了这个还有很多问题，protos 很老了都没更新过。。