### PR TITLE
fix: !confonly missing in http client

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -1,3 +1,4 @@
+// +build !confonly
 package http
 
 import (


### PR DESCRIPTION
http client file from PR #1813 is missing !confonly tag,  cause build error on `v2ctl` with -tags confonly