### PR TITLE
blank row between build and package

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -1,4 +1,5 @@
 // +build !confonly
+
 package http
 
 import (


### PR DESCRIPTION
 There is no newline separating the build tag and the package declaration in proxy/http/client.go