### PR TITLE
Fix self-signed certificates on Windows

### DIFF
--- a/transport/internet/tls/config_windows.go
+++ b/transport/internet/tls/config_windows.go
@@ -6,9 +6,5 @@ package tls
 import "crypto/x509"
 
 func (c *Config) getCertPool() (*x509.CertPool, error) {
-	if c.DisableSystemRoot {
-		return c.loadSelfCertPool()
-	}
-
-	return nil, nil
+	return c.loadSelfCertPool()
 }


### PR DESCRIPTION
Relates PR/Issues: 
https://github.com/v2ray/v2ray-core/issues/1513
https://github.com/shadowsocks/v2ray-plugin/pull/128

It should load the given certificate whether the `DisableSystemRoot` was set or not.

Furthermore, the Windows implementation is also not consistent with other platforms.