### PR TITLE
fixed add new vmess user bug

### DIFF
--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -47,11 +47,11 @@ func newUserByEmail(config *DefaultConfig) *userByEmail {
 
 func (v *userByEmail) addNoLock(u *protocol.MemoryUser) bool {
 	email := strings.ToLower(u.Email)
-	user, found := v.cache[email]
+	_, found := v.cache[email]
 	if found {
 		return false
 	}
-	v.cache[email] = user
+	v.cache[email] = u
 	return true
 }
 


### PR DESCRIPTION
fixed add new vmess user bug.
when add new vmess user, just add the key(u.email) to the map(v.cache), the value of map is nil.