### PR TITLE
by export "UnRegisterConfig" method, we can register the module repeatedly after change something of the module

### DIFF
--- a/common/type.go
+++ b/common/type.go
@@ -22,6 +22,16 @@ func RegisterConfig(config interface{}, configCreator ConfigCreator) error {
 	return nil
 }
 
+// UnRegisterConfig registers a global config creator. The config can be nil but must have a type.
+func UnRegisterConfig(config interface{}) error {
+	configType := reflect.TypeOf(config)
+	if _, found := typeCreatorRegistry[configType]; !found {
+		return newError(configType.Name() + " is not registered").AtError()
+	}
+	delete(typeCreatorRegistry, configType)
+	return nil
+}
+
 // CreateObject creates an object by its config. The config type must be registered through RegisterConfig().
 func CreateObject(ctx context.Context, config interface{}) (interface{}, error) {
 	configType := reflect.TypeOf(config)


### PR DESCRIPTION
example:
```golang
// +build !confonly

package inbound

import (
	"context"

	"v2ray.com/core/common"
	"v2ray.com/core/proxy/vmess/inbound"
)

func init() {
	common.UnRegisterConfig((*inbound.Config)(nil))
	common.Must(common.RegisterConfig((*inbound.Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
		options := inbound.HandlerOptions{
			Clients: &RemoteUserValidator{},
		}
		return inbound.New(ctx, config.(*inbound.Config), options)
	}))
}

```