### PR TITLE
使 vmess inbound 的 clients 可配置, 这样可以实现一个模块替换 vmess 中的验证模块

### DIFF
--- a/common/type.go
+++ b/common/type.go
@@ -22,6 +22,16 @@ func RegisterConfig(config interface{}, configCreator ConfigCreator) error {
 	return nil
 }
 
+// UnRegisterConfig registers a global config creator. The config can be nil but must have a type.
+func UnRegisterConfig(config interface{}) error {
+	configType := reflect.TypeOf(config)
+	if _, found := typeCreatorRegistry[configType]; !found {
+		return newError(configType.Name() + " is not registered").AtError()
+	}
+	delete(typeCreatorRegistry, configType)
+	return nil
+}
+
 // CreateObject creates an object by its config. The config type must be registered through RegisterConfig().
 func CreateObject(ctx context.Context, config interface{}) (interface{}, error) {
 	configType := reflect.TypeOf(config)

--- a/proxy/vmess/encoding/server.go
+++ b/proxy/vmess/encoding/server.go
@@ -89,7 +89,7 @@ func (h *SessionHistory) removeExpiredEntries() error {
 
 // ServerSession keeps information for a session in VMess server.
 type ServerSession struct {
-	userValidator   *vmess.TimedUserValidator
+	userValidator   vmess.UserValidator
 	sessionHistory  *SessionHistory
 	requestBodyKey  [16]byte
 	requestBodyIV   [16]byte
@@ -101,7 +101,7 @@ type ServerSession struct {
 
 // NewServerSession creates a new ServerSession, using the given UserValidator.
 // The ServerSession instance doesn't take ownership of the validator.
-func NewServerSession(validator *vmess.TimedUserValidator, sessionHistory *SessionHistory) *ServerSession {
+func NewServerSession(validator vmess.UserValidator, sessionHistory *SessionHistory) *ServerSession {
 	return &ServerSession{
 		userValidator:  validator,
 		sessionHistory: sessionHistory,

--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -18,6 +18,14 @@ const (
 	cacheDurationSec = 120
 )
 
+// UserValidator interface
+type UserValidator interface {
+	Get(userHash []byte) (*protocol.MemoryUser, protocol.Timestamp, bool)
+	Close() error
+	Add(u *protocol.MemoryUser) error
+	Remove(email string) bool
+}
+
 type user struct {
 	user    protocol.MemoryUser
 	lastSec protocol.Timestamp


### PR DESCRIPTION
有了这个功能的话, 可以实现远程用户验证

`proxy/vmess/inbound-remote/inbound.go`

```golang
// +build !confonly

package inbound

import (
	"context"

	"v2ray.com/core/common"
	"v2ray.com/core/proxy/vmess/inbound"
)

func init() {
	// 取消 vmess inbound 的注册
	common.UnRegisterConfig((*inbound.Config)(nil))
	common.Must(common.RegisterConfig((*inbound.Config)(nil), func(ctx context.Context, config interface{}) (interface{}, error) {
		options := inbound.HandlerOptions{
			// 重新实现用户验证模块
			Clients: &RemoteUserValidator{},
		}
		// 注册修改了用户验证模块后的 vmess inbound
		return inbound.New(ctx, config.(*inbound.Config), options)
	}))
}
```

`proxy/vmess/inbound-remote/validator.go`

```golang
// +build !confonly

package inbound

import "v2ray.com/core/common/protocol"

type RemoteUserValidator struct {
}

// 在这里实现远程用户和本地用户的验证和转换即可
func (v *RemoteUserValidator) Get(userHash []byte) (*protocol.MemoryUser, protocol.Timestamp, bool) {
	return nil, 0, false
}

// 以下三个接口均可不实现
func (v *RemoteUserValidator) Add(u *protocol.MemoryUser) error {
	return nil
}

func (v *RemoteUserValidator) Remove(email string) bool {
	return false
}

// Close implements common.Closable.
func (v *RemoteUserValidator) Close() error {
	return nil
}
```
