### PR TITLE
添加按照出口网速进行选择的负载均衡

### DIFF
--- a/app/router/balancing.go
+++ b/app/router/balancing.go
@@ -8,13 +8,14 @@ import (
 )
 
 type BalancingStrategy interface {
-	PickOutbound([]string) string
+	PickOutbound(outbound.Manager, []string) string
 }
 
 type RandomStrategy struct {
 }
 
-func (s *RandomStrategy) PickOutbound(tags []string) string {
+// PickOutbound implement BalancingStrategy interface
+func (s *RandomStrategy) PickOutbound(_ outbound.Manager, tags []string) string {
 	n := len(tags)
 	if n == 0 {
 		panic("0 tags")
@@ -38,7 +39,7 @@ func (b *Balancer) PickOutbound() (string, error) {
 	if len(tags) == 0 {
 		return "", newError("no available outbounds selected")
 	}
-	tag := b.strategy.PickOutbound(tags)
+	tag := b.strategy.PickOutbound(b.ohm, tags)
 	if tag == "" {
 		return "", newError("balancing strategy returns empty tag")
 	}

--- a/app/router/balancing_optimal_strategy.go
+++ b/app/router/balancing_optimal_strategy.go
@@ -1,0 +1,194 @@
+package router
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"math"
+	"net/http"
+	"net/url"
+	"time"
+
+	"v2ray.com/core/common/net"
+	"v2ray.com/core/common/session"
+	"v2ray.com/core/common/task"
+	"v2ray.com/core/features/outbound"
+	"v2ray.com/core/transport"
+	"v2ray.com/core/transport/pipe"
+)
+
+// OptimalStrategy pick outbound by net speed
+type OptimalStrategy struct {
+	timeout  time.Duration
+	interval time.Duration
+	url      *url.URL
+	count    uint32
+	score    float64
+	obm      outbound.Manager
+	tag      string
+	tags     []string
+	periodic *task.Periodic
+}
+
+// NewOptimalStrategy create new strategy
+func NewOptimalStrategy(config *OptimalStrategyConfig) *OptimalStrategy {
+	s := &OptimalStrategy{}
+	if config.Timeout == 0 {
+		s.timeout = time.Second * 5
+	} else {
+		s.timeout = time.Second * time.Duration(config.Timeout)
+	}
+	if config.Interval == 0 {
+		s.interval = time.Second * 60 * 10
+	} else {
+		s.interval = time.Second * time.Duration(config.Interval)
+	}
+	if config.URL == "" {
+		s.url, _ = url.Parse("https://www.google.com")
+	} else {
+		var err error
+		s.url, err = url.Parse(config.URL)
+		if err != nil {
+			panic(err)
+		}
+		if s.url.Scheme != "http" && s.url.Scheme != "https" {
+			panic("Only http/https url support")
+		}
+	}
+	if config.Count == 0 {
+		s.count = 3
+	} else {
+		s.count = config.Count
+	}
+	s.score = 0
+
+	return s
+}
+
+// PickOutbound implement BalancingStrategy interface
+func (s *OptimalStrategy) PickOutbound(obm outbound.Manager, tags []string) string {
+	if len(tags) == 0 {
+		panic("0 tags")
+	} else if len(tags) == 1 {
+		return s.tag
+	}
+
+	s.obm = obm
+	s.tags = tags
+
+	if s.periodic == nil {
+		s.periodic = &task.Periodic{
+			Interval: s.interval,
+			Execute:  s.run,
+		}
+		s.periodic.Start()
+		s.tag = s.tags[0]
+		return s.tag
+	}
+
+	return s.tag
+}
+
+// periodic execute function
+func (s *OptimalStrategy) run() error {
+	s.score = 0
+
+	for _, tag := range s.tags {
+		scores := make([]float64, 0, s.count)
+		go s.testOutboud(tag, scores)
+	}
+
+	return nil
+}
+
+// Test outbound's network state with multi-round
+func (s *OptimalStrategy) testOutboud(tag string, scores []float64) {
+	// calculate average score and end test round
+	if len(scores) >= int(s.count) {
+		var minScore float64 = float64(math.MaxInt64)
+		var maxScore float64 = float64(math.MinInt64)
+		var sumScore float64
+		var score float64
+
+		for _, score := range scores {
+			if score < minScore {
+				minScore = score
+			}
+			if score > maxScore {
+				maxScore = score
+			}
+			sumScore += score
+		}
+		if len(scores) < 3 {
+			score = sumScore / float64(len(scores))
+		} else {
+			score = (sumScore - minScore - maxScore) / float64(s.count-2)
+		}
+		newError(fmt.Sprintf("Balance OptimalStrategy get %s's score: %.2f", tag, score)).AtDebug().WriteToLog()
+
+		if s.score < score {
+			s.score = score
+			s.tag = tag
+			newError(fmt.Sprintf("Balance OptimalStrategy now pick detour [%s](score: %.2f) from %s", s.tag, s.score, s.tags)).AtInfo().WriteToLog()
+		}
+		return
+	}
+	// test outbound by fetch url
+	oh := s.obm.GetHandler(tag)
+	if oh == nil {
+		newError("Wrong OptimalStrategy tag").AtError().WriteToLog()
+		return
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				netDestination, err := net.ParseDestination(fmt.Sprintf("%s:%s", network, addr))
+				if err != nil {
+					return nil, err
+				}
+
+				uplinkReader, uplinkWriter := pipe.New()
+				downlinkReader, downlinkWriter := pipe.New()
+				ctx = session.ContextWithOutbound(
+					ctx,
+					&session.Outbound{
+						Target: netDestination,
+					})
+				go oh.Dispatch(ctx, &transport.Link{Reader: uplinkReader, Writer: downlinkWriter})
+
+				return net.NewConnection(net.ConnectionInputMulti(uplinkWriter), net.ConnectionOutputMulti(downlinkReader)), nil
+			},
+			MaxConnsPerHost: 1,
+			MaxIdleConns:    1,
+		},
+		Timeout: s.timeout,
+	}
+	startAt := time.Now()
+	// send http request though this outbound
+	req, _ := http.NewRequest("GET", s.url.String(), nil)
+	resp, err := client.Do(req)
+	// use http response speed or time(no http content) as score
+	score := 0.0
+	if err != nil {
+		newError(err).AtError().WriteToLog()
+	} else {
+		contentSize := 0
+		scanner := bufio.NewScanner(resp.Body)
+		for scanner.Scan() {
+			contentSize += len(scanner.Bytes())
+		}
+		if contentSize != 0 {
+			score = float64(contentSize) / (float64(time.Now().UnixNano()-startAt.UnixNano()) / float64(time.Second))
+		} else {
+			// assert http header's Byte size is 100B
+			score = 100 / (float64(time.Now().UnixNano()-startAt.UnixNano()) / float64(time.Second))
+		}
+	}
+	// next test round
+	client.CloseIdleConnections()
+	s.testOutboud(
+		tag,
+		append(scores, score),
+	)
+}

--- a/app/router/balancing_strategy_test.go
+++ b/app/router/balancing_strategy_test.go
@@ -1,0 +1,77 @@
+package router_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"v2ray.com/core/app/proxyman/outbound"
+	. "v2ray.com/core/app/router"
+	"v2ray.com/core/common/buf"
+	"v2ray.com/core/transport"
+)
+
+// mock proxy/outbound/handler
+type mockHandler struct {
+	tag     string
+	timeout time.Duration
+}
+
+func (h *mockHandler) Tag() string {
+	return h.tag
+}
+
+func (h *mockHandler) Start() error {
+	return nil
+}
+
+func (h *mockHandler) Close() error {
+	return nil
+}
+
+func (h *mockHandler) Dispatch(ctx context.Context, link *transport.Link) {
+	mockHTTPResponse := `HTTP/1.1 200 OK
+Date: Mon, 27 Jul 2080 12:28:53 GMT
+Server: MockServer/0.0.1
+Content-Length: 53
+Content-Type: text/html
+Connection: Closed
+
+<html>
+<body>
+<h1>Hello, World!</h1>
+</body>
+</html>
+`
+	link.Reader.ReadMultiBuffer()
+	if h.timeout != 0 {
+		time.Sleep(h.timeout)
+	}
+	link.Writer.WriteMultiBuffer(buf.MergeBytes(buf.MultiBuffer{}, []byte(mockHTTPResponse)))
+}
+
+func TestRandomStrategy(t *testing.T) {
+	strategy := RandomStrategy{}
+	if strategy.PickOutbound(nil, []string{"test"}) != "test" {
+		t.Error("Random strategy test fail")
+	}
+}
+
+func TestOptimalStrategy(t *testing.T) {
+	ctx := context.Background()
+	obm, _ := outbound.New(ctx, nil)
+	obm.AddHandler(ctx, &mockHandler{tag: "test1", timeout: time.Millisecond * 100})
+	obm.AddHandler(ctx, &mockHandler{tag: "test2"})
+	strategy := NewOptimalStrategy(&OptimalStrategyConfig{URL: "http://test.com"})
+
+	tag := strategy.PickOutbound(obm, []string{"test1", "test2"})
+	if tag != "test1" {
+		t.Error("Should pick first tag on start")
+	}
+	// waiting outbound first round test
+	time.Sleep(time.Second * 1)
+	tag = strategy.PickOutbound(obm, []string{"test1", "test2"})
+	if tag != "test2" {
+		t.Error("Should pick fastest tag")
+	}
+}

--- a/app/router/config.go
+++ b/app/router/config.go
@@ -142,9 +142,17 @@ func (rr *RoutingRule) BuildCondition() (Condition, error) {
 }
 
 func (br *BalancingRule) Build(ohm outbound.Manager) (*Balancer, error) {
+	var strategy BalancingStrategy
+
+	if br.Strategy == "optimal" {
+		strategy = NewOptimalStrategy(br.OptimalStrategyConfig)
+	} else if br.Strategy == "" || br.Strategy == "random" {
+		strategy = &RandomStrategy{}
+	}
+
 	return &Balancer{
 		selectors: br.OutboundSelector,
-		strategy:  &RandomStrategy{},
+		strategy:  strategy,
 		ohm:       ohm,
 	}, nil
 }

--- a/app/router/config.pb.go
+++ b/app/router/config.pb.go
@@ -2,8 +2,9 @@ package router
 
 import (
 	fmt "fmt"
-	proto "github.com/golang/protobuf/proto"
 	math "math"
+
+	proto "github.com/golang/protobuf/proto"
 	net "v2ray.com/core/common/net"
 )
 
@@ -659,12 +660,25 @@ func (*RoutingRule) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+type OptimalStrategyConfig struct {
+	Timeout  uint32 `protobuf:"varint,1,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	Interval uint32 `protobuf:"varint,2,opt,name=interval,proto3" json:"interval,omitempty"`
+	URL      string `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	Count    uint32 `protobuf:"varint,5,opt,name=count,proto3" json:"count,omitempty"`
+}
+
+func (m *OptimalStrategyConfig) Reset()         { *m = OptimalStrategyConfig{} }
+func (m *OptimalStrategyConfig) String() string { return proto.CompactTextString(m) }
+func (*OptimalStrategyConfig) ProtoMessage()    {}
+
 type BalancingRule struct {
-	Tag                  string   `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
-	OutboundSelector     []string `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	Tag                   string                 `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	OutboundSelector      []string               `protobuf:"bytes,2,rep,name=outbound_selector,json=outboundSelector,proto3" json:"outbound_selector,omitempty"`
+	Strategy              string                 `protobuf:"bytes,3,opt,name=strategy,json=strategy,proto3" json:"strategy,omitempty"`
+	OptimalStrategyConfig *OptimalStrategyConfig `protobuf:"bytes,4,opt,name=optimal_strategy_config,json=optimal_strategy_config,proto3" json:"optimal_strategy_config,omitempty"`
+	XXX_NoUnkeyedLiteral  struct{}               `json:"-"`
+	XXX_unrecognized      []byte                 `json:"-"`
+	XXX_sizecache         int32                  `json:"-"`
 }
 
 func (m *BalancingRule) Reset()         { *m = BalancingRule{} }
@@ -702,6 +716,13 @@ func (m *BalancingRule) GetTag() string {
 func (m *BalancingRule) GetOutboundSelector() []string {
 	if m != nil {
 		return m.OutboundSelector
+	}
+	return nil
+}
+
+func (m *BalancingRule) GetOptimalStrategyConfig() *OptimalStrategyConfig {
+	if m != nil {
+		return m.OptimalStrategyConfig
 	}
 	return nil
 }

--- a/app/router/config.proto
+++ b/app/router/config.proto
@@ -117,9 +117,19 @@ message RoutingRule {
   string attributes = 15;
 }
 
+message BalancingOptimalStrategyConfig {
+  uint32 timeout = 1;
+  uint32 interval = 2;
+  string target = 3;
+	string content = 4;
+  uint32 count = 5;
+}
+
 message BalancingRule {
   string tag = 1;
   repeated string outbound_selector = 2;
+  string strategy = 3;
+  BalancingOptimalStrategyConfig optimal_strategy_config = 4;
 }
 
 message Config {

--- a/infra/conf/router.go
+++ b/infra/conf/router.go
@@ -17,9 +17,19 @@ type RouterRulesConfig struct {
 	DomainStrategy string            `json:"domainStrategy"`
 }
 
+// BalancingOptimalStrategyConfig store BalancingOptimalStrategy config
+type BalancingOptimalStrategyConfig struct {
+	Timeout  uint32 `protobuf:"bytes,1,opt,name=timeout,proto3" json:"timeout,omitempty"`
+	Interval uint32 `protobuf:"bytes,2,opt,name=interval,proto3" json:"interval,omitempty"`
+	URL      string `protobuf:"bytes,3,opt,name=url,proto3" json:"url,omitempty"`
+	Count    uint32 `protobuf:"bytes,5,opt,name=count,proto3" json:"count,omitempty"`
+}
+
 type BalancingRule struct {
-	Tag       string     `json:"tag"`
-	Selectors StringList `json:"selector"`
+	Tag                   string                          `json:"tag"`
+	Selectors             StringList                      `json:"selector"`
+	Strategy              string                          `json:"strategy"`
+	OptimalStrategyConfig *BalancingOptimalStrategyConfig `json:"optimal_strategy_config"`
 }
 
 func (r *BalancingRule) Build() (*router.BalancingRule, error) {
@@ -30,9 +40,19 @@ func (r *BalancingRule) Build() (*router.BalancingRule, error) {
 		return nil, newError("empty selector list")
 	}
 
+	optimalStrategyConfig := &router.OptimalStrategyConfig{}
+	if r.OptimalStrategyConfig != nil {
+		optimalStrategyConfig.Timeout = r.OptimalStrategyConfig.Timeout
+		optimalStrategyConfig.Interval = r.OptimalStrategyConfig.Interval
+		optimalStrategyConfig.URL = r.OptimalStrategyConfig.URL
+		optimalStrategyConfig.Count = r.OptimalStrategyConfig.Count
+	}
+
 	return &router.BalancingRule{
-		Tag:              r.Tag,
-		OutboundSelector: []string(r.Selectors),
+		Tag:                   r.Tag,
+		OutboundSelector:      []string(r.Selectors),
+		Strategy:              r.Strategy,
+		OptimalStrategyConfig: optimalStrategyConfig,
 	}, nil
 }
 

--- a/infra/conf/router_test.go
+++ b/infra/conf/router_test.go
@@ -58,7 +58,14 @@ func TestRouterConfig(t *testing.T) {
 				"balancers": [
 					{
 						"tag": "b1",
-						"selector": ["test"]
+						"selector": ["test"],
+						"strategy": "optimal",
+						"optimal_strategy_config": {
+							"timeout": 10,
+							"interval": 120,
+							"url": "http://test.com",
+							"count": 1
+						}
 					}
 				]
 			}`,
@@ -69,6 +76,13 @@ func TestRouterConfig(t *testing.T) {
 					{
 						Tag:              "b1",
 						OutboundSelector: []string{"test"},
+						Strategy:         "optimal",
+						OptimalStrategyConfig: &router.OptimalStrategyConfig{
+							Timeout:  10,
+							Interval: 120,
+							URL:      "http://test.com",
+							Count:    1,
+						},
 					},
 				},
 				Rule: []*router.RoutingRule{


### PR DESCRIPTION
相关issues:#1857 #1825 

简单实现了下按照网速快慢来进行负载均衡，定时向相关的outbound发送请求，按照网速选择最优

TOOD：
1. 如何注入配置，不知道是否接受下面的配置，或者其他方式, done
```
    "balancers": [
      {
        "tag": "b1",
        "strategy": "optimal",   //new
        "optimal_strategy_config": {
          "timeout": 60,
          "interval": 120, //多久进行一次测速
          "url": "https://github.com/v2ray/v2ray-core/releases/download/v4.21.3/v2ray-linux-64.zip",
          "count": 1 // 一次测速中测试几轮，最后会取平均值得分
        },
        "selector": [
          "jms4",
          "jms3",
          "jms2",
          "jms1",
        ]
      }
```
2，支持HTTP/HTTPS测试 done
3，测试覆盖率 done

关于测试链接的选择，就这俩天自己使用情况来看，如果是为了照顾浏览网页等内容小但频率高的场景，可以选择返回内容少的targer，进行多轮测试选择平均值；相反，如果为了看视频更快点，可以选择返回内容多的targer，进行单轮测试拿到网速进行比较选择。网络环境错综复杂，如果有更好的策略欢迎讨论

 waiting for review 第一次写go项目，欢迎各种指正😅