### PR TITLE
change the v2ray dir from `/usr/bin/v2ray` to `/usr/lib/v2ray` in the script

### DIFF
--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -11,8 +11,11 @@ Wants=network.target
 # Group=v2ray
 Type=simple
 PIDFile=/run/v2ray.pid
-ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
+ExecStart=/usr/lib/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
+StandardOut=/var/log/v2ray/std.log
+StandardError=/var/log/v2ray/err.log
+
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23
 

--- a/release/config/systemv/v2ray
+++ b/release/config/systemv/v2ray
@@ -13,7 +13,7 @@
 
 DESC=v2ray
 NAME=v2ray
-DAEMON=/usr/bin/v2ray/v2ray
+DAEMON=/usr/lib/v2ray/v2ray
 PIDFILE=/var/run/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 

--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -204,7 +204,7 @@ getVersion(){
         fi
         return 4
     else
-        VER=`/usr/bin/v2ray/v2ray -version 2>/dev/null`
+        VER=`/usr/lib/v2ray/v2ray -version 2>/dev/null`
         RETVAL="$?"
         CUR_VER=`echo $VER | head -n 1 | cut -d " " -f2`
         if [[ ${CUR_VER} != v* ]]; then
@@ -258,7 +258,7 @@ startV2ray(){
 
 copyFile() {
     NAME=$1
-    ERROR=`cp "${VSRC_ROOT}/${NAME}" "/usr/bin/v2ray/${NAME}" 2>&1`
+    ERROR=`cp "${VSRC_ROOT}/${NAME}" "/usr/lib/v2ray/${NAME}" 2>&1`
     if [[ $? -ne 0 ]]; then
         colorEcho ${YELLOW} "${ERROR}"
         return 1
@@ -267,12 +267,12 @@ copyFile() {
 }
 
 makeExecutable() {
-    chmod +x "/usr/bin/v2ray/$1"
+    chmod +x "/usr/lib/v2ray/$1"
 }
 
 installV2Ray(){
-    # Install V2Ray binary to /usr/bin/v2ray
-    mkdir -p /usr/bin/v2ray
+    # Install V2Ray binary to /usr/lib/v2ray
+    mkdir -p /usr/lib/v2ray
     copyFile v2ray
     if [[ $? -ne 0 ]]; then
         colorEcho ${RED} "Failed to copy V2Ray binary and resources."
@@ -341,7 +341,7 @@ remove(){
             stopV2ray
         fi
         systemctl disable v2ray.service
-        rm -rf "/usr/bin/v2ray" "/etc/systemd/system/v2ray.service"
+        rm -rf "/usr/lib/v2ray" "/etc/systemd/system/v2ray.service"
         if [[ $? -ne 0 ]]; then
             colorEcho ${RED} "Failed to remove V2Ray."
             return 0
@@ -355,7 +355,7 @@ remove(){
             stopV2ray
         fi
         systemctl disable v2ray.service
-        rm -rf "/usr/bin/v2ray" "/lib/systemd/system/v2ray.service"
+        rm -rf "/usr/lib/v2ray" "/lib/systemd/system/v2ray.service"
         if [[ $? -ne 0 ]]; then
             colorEcho ${RED} "Failed to remove V2Ray."
             return 0
@@ -368,7 +368,7 @@ remove(){
         if pgrep "v2ray" > /dev/null ; then
             stopV2ray
         fi
-        rm -rf "/usr/bin/v2ray" "/etc/init.d/v2ray"
+        rm -rf "/usr/lib/v2ray" "/etc/init.d/v2ray"
         if [[ $? -ne 0 ]]; then
             colorEcho ${RED} "Failed to remove V2Ray."
             return 0


### PR DESCRIPTION
感谢v2ray开发者目前所有的付出，很好用，提个想到的鸡毛蒜皮的建议
不影响使用，只是强迫症不舒服

因为好像`/usr/bin`是不放目录的，感觉放`/usr/lib/v2ray`比较合适
而且也没有必要放`/usr/bin/`，不需要命令行执行，对吧？

把脚本改了下，本来放到`/usr/bin/v2ray`的放到`/usr/lib/v2ray/`

根据[iochen的回复](https://github.com/v2ray/discussion/issues/385#issuecomment-538601510)
v2ray.service 添加了`StandardOut`和`StandardError`

因为看代码会读取`geosite.dat`和`geoip.dat`，如果需要命令行的话，可能需要添加配置文件或命令行参数

如果考虑兼容更多发行版的自启动可以调研下用`cron`的可行性

UPDATED: changed `v2ray` file of systemV.