### PR TITLE
access log add detour tag

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -14,6 +14,7 @@ import (
 	"v2ray.com/core/common"
 	"v2ray.com/core/common/buf"
 	"v2ray.com/core/common/net"
+	"v2ray.com/core/common/log"
 	"v2ray.com/core/common/protocol"
 	"v2ray.com/core/common/session"
 	"v2ray.com/core/features/outbound"
@@ -279,6 +280,12 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 		common.Close(link.Writer)
 		common.Interrupt(link.Reader)
 		return
+	}
+
+	accessMessage := log.AccessMessageFromContext(ctx)
+	if accessMessage != nil {
+		accessMessage.Detour = "[" + handler.Tag() + "]"
+		log.Record(accessMessage)
 	}
 
 	handler.Dispatch(ctx, link)

--- a/common/log/access.go
+++ b/common/log/access.go
@@ -1,9 +1,16 @@
 package log
 
 import (
+	"context"
 	"strings"
 
 	"v2ray.com/core/common/serial"
+)
+
+type logKey int
+
+const (
+	accessMessageKey logKey = iota
 )
 
 type AccessStatus string
@@ -19,6 +26,7 @@ type AccessMessage struct {
 	Status AccessStatus
 	Reason interface{}
 	Email  string
+	Detour interface{}
 }
 
 func (m *AccessMessage) String() string {
@@ -29,6 +37,8 @@ func (m *AccessMessage) String() string {
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.To))
 	builder.WriteByte(' ')
+	builder.WriteString(serial.ToString(m.Detour))
+	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.Reason))
 
 	if len(m.Email) > 0 {
@@ -37,4 +47,15 @@ func (m *AccessMessage) String() string {
 		builder.WriteByte(' ')
 	}
 	return builder.String()
+}
+
+func ContextWithAccessMessage(ctx context.Context, accessMessage *AccessMessage) context.Context {
+	return context.WithValue(ctx, accessMessageKey, accessMessage)
+}
+
+func AccessMessageFromContext(ctx context.Context) *AccessMessage {
+	if accessMessage, ok := ctx.Value(accessMessageKey).(*AccessMessage); ok {
+		return accessMessage
+	}
+	return nil
 }

--- a/common/mux/server.go
+++ b/common/mux/server.go
@@ -120,7 +120,7 @@ func (w *ServerWorker) handleStatusNew(ctx context.Context, meta *FrameMetadata,
 			msg.From = inbound.Source
 			msg.Email = inbound.User.Email
 		}
-		log.Record(msg)
+		ctx = log.ContextWithAccessMessage(ctx, msg)
 	}
 	link, err := w.dispatcher.Dispatch(ctx, meta.Target)
 	if err != nil {

--- a/proxy/http/server.go
+++ b/proxy/http/server.go
@@ -131,10 +131,11 @@ Start:
 	if err != nil {
 		return newError("malformed proxy host: ", host).AtWarning().Base(err)
 	}
-	log.Record(&log.AccessMessage{
+	ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 		From:   conn.RemoteAddr(),
 		To:     request.URL,
 		Status: log.AccessAccepted,
+		Reason: "",
 	})
 
 	if strings.EqualFold(request.Method, "CONNECT") {

--- a/proxy/shadowsocks/server.go
+++ b/proxy/shadowsocks/server.go
@@ -134,7 +134,7 @@ func (s *Server) handlerUDPPayload(ctx context.Context, conn internet.Connection
 
 			dest := request.Destination()
 			if inbound.Source.IsValid() {
-				log.Record(&log.AccessMessage{
+				ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 					From:   inbound.Source,
 					To:     dest,
 					Status: log.AccessAccepted,
@@ -176,7 +176,7 @@ func (s *Server) handleConnection(ctx context.Context, conn internet.Connection,
 	inbound.User = s.user
 
 	dest := request.Destination()
-	log.Record(&log.AccessMessage{
+	ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 		From:   conn.RemoteAddr(),
 		To:     dest,
 		Status: log.AccessAccepted,

--- a/proxy/socks/server.go
+++ b/proxy/socks/server.go
@@ -117,7 +117,7 @@ func (s *Server) processTCP(ctx context.Context, conn internet.Connection, dispa
 		dest := request.Destination()
 		newError("TCP Connect request to ", dest).WriteToLog(session.ExportIDToError(ctx))
 		if inbound != nil && inbound.Source.IsValid() {
-			log.Record(&log.AccessMessage{
+			ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 				From:   inbound.Source,
 				To:     dest,
 				Status: log.AccessAccepted,
@@ -229,7 +229,7 @@ func (s *Server) handleUDPPayload(ctx context.Context, conn internet.Connection,
 
 			newError("send packet to ", request.Destination(), " with ", payload.Len(), " bytes").AtDebug().WriteToLog(session.ExportIDToError(ctx))
 			if inbound := session.InboundFromContext(ctx); inbound != nil && inbound.Source.IsValid() {
-				log.Record(&log.AccessMessage{
+				ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 					From:   inbound.Source,
 					To:     request.Destination(),
 					Status: log.AccessAccepted,

--- a/proxy/vmess/inbound/inbound.go
+++ b/proxy/vmess/inbound/inbound.go
@@ -250,7 +250,7 @@ func (h *Handler) Process(ctx context.Context, network net.Network, connection i
 	}
 
 	if request.Command != protocol.RequestCommandMux {
-		log.Record(&log.AccessMessage{
+		ctx = log.ContextWithAccessMessage(ctx, &log.AccessMessage{
 			From:   connection.RemoteAddr(),
 			To:     request.Destination(),
 			Status: log.AccessAccepted,


### PR DESCRIPTION
把v2fly那边的提交合过来了. https://github.com/v2fly/v2ray-core/pull/5

和那时候的相比, 把mux的打印也加上了

issue: #1639

效果
```
2019/06/06 14:55:52 tcp:127.0.0.1:4187 accepted tcp:www.google.com:443 [proxy]
2019/06/06 14:55:54 tcp:127.0.0.1:4190 accepted tcp:www.baidu.com:443 [direct]
```



