### PR TITLE
check detour tag size

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -13,8 +13,8 @@ import (
 	"v2ray.com/core"
 	"v2ray.com/core/common"
 	"v2ray.com/core/common/buf"
-	"v2ray.com/core/common/net"
 	"v2ray.com/core/common/log"
+	"v2ray.com/core/common/net"
 	"v2ray.com/core/common/protocol"
 	"v2ray.com/core/common/session"
 	"v2ray.com/core/features/outbound"
@@ -284,7 +284,11 @@ func (d *DefaultDispatcher) routedDispatch(ctx context.Context, link *transport.
 
 	accessMessage := log.AccessMessageFromContext(ctx)
 	if accessMessage != nil {
-		accessMessage.Detour = "[" + handler.Tag() + "]"
+		if len(handler.Tag()) > 0 {
+			accessMessage.Detour = handler.Tag()
+		} else {
+			accessMessage.Detour = ""
+		}
 		log.Record(accessMessage)
 	}
 

--- a/common/log/access.go
+++ b/common/log/access.go
@@ -26,7 +26,7 @@ type AccessMessage struct {
 	Status AccessStatus
 	Reason interface{}
 	Email  string
-	Detour interface{}
+	Detour string
 }
 
 func (m *AccessMessage) String() string {
@@ -37,8 +37,11 @@ func (m *AccessMessage) String() string {
 	builder.WriteByte(' ')
 	builder.WriteString(serial.ToString(m.To))
 	builder.WriteByte(' ')
-	builder.WriteString(serial.ToString(m.Detour))
-	builder.WriteByte(' ')
+	if len(m.Detour) > 0 {
+		builder.WriteByte('[')
+		builder.WriteString(m.Detour)
+		builder.WriteString("] ")
+	}
 	builder.WriteString(serial.ToString(m.Reason))
 
 	if len(m.Email) > 0 {


### PR DESCRIPTION
判断了下 `handler.Tag()`. 
有可能是空的, 导致只打印了一个`[]`