### PR TITLE
revert 3b087bf , causes tls cert unknown on win

### DIFF
--- a/transport/internet/tls/config_windows.go
+++ b/transport/internet/tls/config_windows.go
@@ -6,5 +6,9 @@ package tls
 import "crypto/x509"
 
 func (c *Config) getCertPool() (*x509.CertPool, error) {
-	return c.loadSelfCertPool()
+	if c.DisableSystemRoot {
+		return c.loadSelfCertPool()
+	}
+
+	return nil, nil
 }


### PR DESCRIPTION
commit 3b087bf8c46bf0fda753d6015c40ede45122b765 brings broken change on windows, on setting 
`allowInsecure: false`, outbound TLS would refuse on correct certificates, needed to revert.

```
failed to dial to (wss://domain:443/path):  > x509: certificate signed by unknown authority 
```