### PR TITLE
Fixed call the Interrupt() after Close(), can't put MutilBuffer into pool.

### DIFF
--- a/transport/pipe/impl.go
+++ b/transport/pipe/impl.go
@@ -187,16 +187,16 @@ func (p *pipe) Interrupt() {
 	p.Lock()
 	defer p.Unlock()
 
+	if p.data != nil && !p.data.IsEmpty() {
+		buf.ReleaseMulti(p.data)
+		p.data = nil
+	}
+
 	if p.state == closed || p.state == errord {
 		return
 	}
 
 	p.state = errord
-
-	if !p.data.IsEmpty() {
-		buf.ReleaseMulti(p.data)
-		p.data = nil
-	}
 
 	common.Must(p.done.Close())
 }


### PR DESCRIPTION
Fixed call the Interrupt() after Close(), can't put MutilBuffer into pool.