### PR TITLE
Earlylogger

### DIFF
--- a/app/log/log.go
+++ b/app/log/log.go
@@ -29,6 +29,13 @@ func New(ctx context.Context, config *Config) (*Instance, error) {
 	}
 	log.RegisterHandler(g)
 
+	// start logger instantly on inited
+	// other modules would log during init
+	if err := g.startInternal(); err != nil {
+		return nil, err
+	}
+
+	newError("Logger started").AtDebug().WriteToLog()
 	return g, nil
 }
 
@@ -81,13 +88,7 @@ func (g *Instance) startInternal() error {
 
 // Start implements common.Runnable.Start().
 func (g *Instance) Start() error {
-	if err := g.startInternal(); err != nil {
-		return err
-	}
-
-	newError("Logger started").AtDebug().WriteToLog()
-
-	return nil
+	return g.startInternal()
 }
 
 // Handle implements log.Handler.

--- a/infra/conf/v2ray.go
+++ b/infra/conf/v2ray.go
@@ -341,11 +341,15 @@ func (c *Config) Build() (*core.Config, error) {
 		config.App = append(config.App, serial.ToTypedMessage(statsConf))
 	}
 
+	var logConfMsg *serial.TypedMessage
 	if c.LogConfig != nil {
-		config.App = append(config.App, serial.ToTypedMessage(c.LogConfig.Build()))
+		logConfMsg = serial.ToTypedMessage(c.LogConfig.Build())
 	} else {
-		config.App = append(config.App, serial.ToTypedMessage(DefaultLogConfig()))
+		logConfMsg = serial.ToTypedMessage(DefaultLogConfig())
 	}
+	// let logger module be the first App to start,
+	// so that other modules could print log during initiating
+	config.App = append([]*serial.TypedMessage{logConfMsg}, config.App...)
 
 	if c.RouterConfig != nil {
 		routerConfig, err := c.RouterConfig.Build()


### PR DESCRIPTION
Load logger module as early as possible, so that other modules could print their own logs during program initiating.

Here's example logs during the initial running.

```
V2Ray 4.21.4 (user) 20191115-171558
A unified platform for anti-censorship.
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/log: Logger started
2019/11/19 14:10:09 [Info] v2ray.com/core/app/dns: DNS: classic server inited 1.1.1.1:53
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/stats: create new counter inbound>>>proxy>>>traffic>>>uplink
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/stats: create new counter inbound>>>proxy>>>traffic>>>downlink
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/proxyman/inbound: creating stream worker on 0.0.0.0:10808
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/stats: create new counter inbound>>>api>>>traffic>>>uplink
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/stats: create new counter inbound>>>api>>>traffic>>>downlink
2019/11/19 14:10:09 [Debug] v2ray.com/core/app/proxyman/inbound: creating stream worker on 127.0.0.1:64387
2019/11/19 14:10:09 [Info] v2ray.com/core/transport/internet/tcp: listening TCP on 0.0.0.0:10808
2019/11/19 14:10:09 [Info] v2ray.com/core/transport/internet/udp: listening UDP on 0.0.0.0:10808
2019/11/19 14:10:09 [Info] v2ray.com/core/transport/internet/tcp: listening TCP on 127.0.0.1:64387
2019/11/19 14:10:09 [Warning] v2ray.com/core: V2Ray 4.21.4 started
```