### PR TITLE
properly propagate Reader errors

### DIFF
--- a/common/buf/buffer.go
+++ b/common/buf/buffer.go
@@ -131,7 +131,7 @@ func (b *Buffer) IsEmpty() bool {
 
 // IsFull returns true if the buffer has no more room to grow.
 func (b *Buffer) IsFull() bool {
-	return b.end == int32(len(b.v))
+	return b != nil && b.end == int32(len(b.v))
 }
 
 // Write implements Write method in io.Writer.

--- a/common/buf/reader.go
+++ b/common/buf/reader.go
@@ -27,12 +27,12 @@ func readOneUDP(r io.Reader) (*Buffer, error) {
 // ReadBuffer reads a Buffer from the given reader.
 func ReadBuffer(r io.Reader) (*Buffer, error) {
 	b := New()
-	_, err := b.ReadFrom(r)
-	if err != nil {
-		b.Release()
-		return nil, err
+	n, err := b.ReadFrom(r)
+	if n > 0 {
+		return b, err
 	}
-	return b, nil
+	b.Release()
+	return nil, err
 }
 
 // BufferedReader is a Reader that keeps its internal buffer.
@@ -156,10 +156,7 @@ type SingleReader struct {
 // ReadMultiBuffer implements Reader.
 func (r *SingleReader) ReadMultiBuffer() (MultiBuffer, error) {
 	b, err := ReadBuffer(r.Reader)
-	if err != nil {
-		return nil, err
-	}
-	return MultiBuffer{b}, nil
+	return MultiBuffer{b}, err
 }
 
 // PacketReader is a Reader that read one Buffer every time.

--- a/common/buf/readv_reader.go
+++ b/common/buf/readv_reader.go
@@ -120,13 +120,10 @@ func (r *ReadVReader) readMulti() (MultiBuffer, error) {
 func (r *ReadVReader) ReadMultiBuffer() (MultiBuffer, error) {
 	if r.alloc.Current() == 1 {
 		b, err := ReadBuffer(r.Reader)
-		if err != nil {
-			return nil, err
-		}
 		if b.IsFull() {
 			r.alloc.Adjust(1)
 		}
-		return MultiBuffer{b}, nil
+		return MultiBuffer{b}, err
 	}
 
 	mb, err := r.readMulti()


### PR DESCRIPTION
Previously the ReadBuffer() uses in SingleReader and ReadVReader are both not correctly propagate read errors. Specifically, this PR fixes the case where the underlying io.Reader returns some data and io.EOF in the same time.