### PR TITLE
v2ray.service upgrade

### DIFF
--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -1,16 +1,20 @@
 [Unit]
-Description=V2Ray Service
-After=network.target
-Wants=network.target
+Description=V2Ray - A unified platform for anti-censorship.
+Documentation=https://v2ray.com
+After=network.target nss-lookup.target
+Wants=network-online.target nss-lookup.target
 
 [Service]
+# If the version of systemd is earlier than 240, then change Type=exec to Type=simple
+#Type=simple
+Type=exec
 # This service runs as root. You may consider to run it as another user for security concerns.
 # By uncommenting the following two lines, this service will run as user v2ray/v2ray.
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
 # User=v2ray
-# Group=v2ray
-Type=simple
-PIDFile=/run/v2ray.pid
+# runs as a root or add CAP_NET_BIND_SERVICE ability can bind 1 to 1024 port
+User=root
+#AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
 # Don't restart in the case of configuration error

--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -2,18 +2,18 @@
 Description=V2Ray - A unified platform for anti-censorship.
 Documentation=https://v2ray.com
 After=network.target nss-lookup.target
-Wants=network-online.target nss-lookup.target
+Wants=network-online.target
 
 [Service]
-# If the version of systemd is 240 or above,  then change Type=simple to Type=exec
+# If the version of systemd is 240 or above,  then uncommenting Type=simple and commenting out Type=exec
 #Type=exec
 Type=simple
+# Runs as a root or add CAP_NET_BIND_SERVICE ability can bind 1 to 1024 port.
 # This service runs as root. You may consider to run it as another user for security concerns.
-# By uncommenting the following two lines, this service will run as user v2ray/v2ray.
+# By uncommenting User=v2ray and commenting out User=root, the service will run as user v2ray.
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
-# User=v2ray
-# runs as a root or add CAP_NET_BIND_SERVICE ability can bind 1 to 1024 port
 User=root
+#User=v2ray
 #AmbientCapabilities=CAP_NET_BIND_SERVICE
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure

--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -5,9 +5,9 @@ After=network.target nss-lookup.target
 Wants=network-online.target nss-lookup.target
 
 [Service]
-# If the version of systemd is earlier than 240, then change Type=exec to Type=simple
-#Type=simple
-Type=exec
+# If the version of systemd is 240 or above,  then change Type=simple to Type=exec
+#Type=exec
+Type=simple
 # This service runs as root. You may consider to run it as another user for security concerns.
 # By uncommenting the following two lines, this service will run as user v2ray/v2ray.
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011


### PR DESCRIPTION
做了一点微小的工作，例如：
去掉了在非 `forking` 类型中几乎无意义的 `PIDFile` （[因为 systemd 不会写入](https://www.freedesktop.org/software/systemd/man/systemd.service.html#PIDFile=)）
把[不推荐使用](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/)的 `Wants=network.target` 换成 `Wants=network-online.target nss-lookup.target`