### PR TITLE
Reduce http proxy client overhead by 1RTT

### DIFF
--- a/proxy/http/client.go
+++ b/proxy/http/client.go
@@ -24,6 +24,7 @@ import (
 	"v2ray.com/core/transport/internet"
 )
 
+// Client is a inbound handler for HTTP protocol
 type Client struct {
 	serverPicker  protocol.ServerPicker
 	policyManager policy.Manager
@@ -92,7 +93,7 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 		p = c.policyManager.ForLevel(user.Level)
 	}
 
-	if err := setUpHttpTunnel(conn, &destination, user); err != nil {
+	if err := setUpHTTPTunnel(conn, &destination, user); err != nil {
 		return err
 	}
 
@@ -124,8 +125,8 @@ func (c *Client) Process(ctx context.Context, link *transport.Link, dialer inter
 	return nil
 }
 
-// setUpHttpTunnel will create a socket tunnel via HTTP CONNECT method
-func setUpHttpTunnel(writer io.Writer, destination *net.Destination, user *protocol.MemoryUser) error {
+// setUpHTTPTunnel will create a socket tunnel via HTTP CONNECT method
+func setUpHTTPTunnel(writer io.Writer, destination *net.Destination, user *protocol.MemoryUser) error {
 	var headers []string
 	destNetAddr := destination.NetAddr()
 	headers = append(headers, "CONNECT "+destNetAddr+" HTTP/1.1")


### PR DESCRIPTION
In standard HTTP proxy, client will wait until proxy connects to the destination and send 200 OK back. This introduce 1 RTT overhead. If we send the content right after writing the CONNECT command, this could be eliminated.
As for compatibility, a standard http proxy should be able to separate the command and content by \r\n\r\n. In my test, most proxy server can handle this behavior.