### PR TITLE
修复迅雷问题

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -216,9 +216,11 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 			}
 			if err == nil && shouldOverride(result, sniffingRequest.OverrideDestinationForProtocol) {
 				domain := result.Domain()
-				newError("sniffed domain: ", domain).WriteToLog(session.ExportIDToError(ctx))
-				destination.Address = net.ParseAddress(domain)
-				ob.Target = destination
+				if strings.Compare(domain,"res.res.res.res") != 0 {
+					newError("sniffed domain: ", domain).WriteToLog(session.ExportIDToError(ctx))
+					destination.Address = net.ParseAddress(domain)
+					ob.Target = destination
+				}
 			}
 			d.routedDispatch(ctx, outbound, destination)
 		}()


### PR DESCRIPTION
#2075 在这个 issue 中我提到了开启 sniffing 会导致安卓迅雷无法使用，我仔细排查了一下，迅雷会发出一个包含 res.res.res.res 的 POST，v2ray 获取这个域名之后会解析，但是解析不出来，导致失败。

我提交的代码只是解决了迅雷的问题，如果想要解决诸如此类的问题，应该在域名解析失败后按照原来的目的地址发送，但这超出了我的能力范围。