### PR TITLE
add arg -confdir

### DIFF
--- a/common/platform/ctlcmd/ctlcmd.go
+++ b/common/platform/ctlcmd/ctlcmd.go
@@ -36,7 +36,7 @@ func Run(args []string, input io.Reader) (buf.MultiBuffer, error) {
 	if err := cmd.Wait(); err != nil {
 		msg := "failed to execute v2ctl"
 		if errBuffer.Len() > 0 {
-			msg += ": " + errBuffer.MultiBuffer.String()
+			msg += ": \n" + strings.TrimSpace(errBuffer.MultiBuffer.String())
 		}
 		return nil, newError(msg).Base(err)
 	}

--- a/common/platform/ctlcmd/ctlcmd.go
+++ b/common/platform/ctlcmd/ctlcmd.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	"v2ray.com/core/common/buf"
 	"v2ray.com/core/common/platform"
@@ -42,7 +43,7 @@ func Run(args []string, input io.Reader) (buf.MultiBuffer, error) {
 
 	// log stderr, info message
 	if !errBuffer.IsEmpty() {
-		newError("v2ctl > \n", errBuffer.MultiBuffer.String()).AtInfo().WriteToLog()
+		newError("<v2ctl message> \n", strings.TrimSpace(errBuffer.MultiBuffer.String())).AtInfo().WriteToLog()
 	}
 
 	return outBuffer.MultiBuffer, nil

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -83,3 +83,9 @@ func GetConfigurationPath() string {
 	configPath := NewEnvFlag(name).GetValue(getExecutableDir)
 	return filepath.Join(configPath, "config.json")
 }
+
+func GetConfDirPath() string {
+	const name = "v2ray.location.confdir"
+	configPath := NewEnvFlag(name).GetValue(getExecutableDir)
+	return configPath
+}

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -84,6 +84,7 @@ func GetConfigurationPath() string {
 	return filepath.Join(configPath, "config.json")
 }
 
+// GetConfDirPath reads "v2ray.location.confdir"
 func GetConfDirPath() string {
 	const name = "v2ray.location.confdir"
 	configPath := NewEnvFlag(name).GetValue(func() string { return "" })

--- a/common/platform/platform.go
+++ b/common/platform/platform.go
@@ -86,6 +86,6 @@ func GetConfigurationPath() string {
 
 func GetConfDirPath() string {
 	const name = "v2ray.location.confdir"
-	configPath := NewEnvFlag(name).GetValue(getExecutableDir)
+	configPath := NewEnvFlag(name).GetValue(func() string { return "" })
 	return configPath
 }

--- a/infra/conf/v2ray.go
+++ b/infra/conf/v2ray.go
@@ -2,6 +2,8 @@ package conf
 
 import (
 	"encoding/json"
+	"log"
+	"os"
 	"strings"
 
 	"v2ray.com/core"
@@ -31,6 +33,8 @@ var (
 		"mtproto":     func() interface{} { return new(MTProtoClientConfig) },
 		"dns":         func() interface{} { return new(DnsOutboundConfig) },
 	}, "protocol", "settings")
+
+	ctllog = log.New(os.Stderr, "v2ctl> ", 0)
 )
 
 func toProtocolList(s []string) ([]proxyman.KnownProtocols, error) {
@@ -361,10 +365,10 @@ func (c *Config) Override(o *Config, fn string) {
 		if len(c.InboundConfigs) > 0 && len(o.InboundConfigs) == 1 {
 			if idx := c.findInboundTag(o.InboundConfigs[0].Tag); idx > -1 {
 				c.InboundConfigs[idx] = o.InboundConfigs[0]
-				newError("<", fn, "> updated inbound with tag: ", o.InboundConfigs[0].Tag).AtInfo().WriteToLog()
+				ctllog.Println("[", fn, "] updated inbound with tag: ", o.InboundConfigs[0].Tag)
 			} else {
 				c.InboundConfigs = append(c.InboundConfigs, o.InboundConfigs[0])
-				newError("<", fn, "> appended inbound with tag: ", o.InboundConfigs[0].Tag).AtInfo().WriteToLog()
+				ctllog.Println("[", fn, "] appended inbound with tag: ", o.InboundConfigs[0].Tag)
 			}
 		} else {
 			c.InboundConfigs = o.InboundConfigs
@@ -376,14 +380,14 @@ func (c *Config) Override(o *Config, fn string) {
 		if len(c.OutboundConfigs) > 0 && len(o.OutboundConfigs) == 1 {
 			if idx := c.findOutboundTag(o.OutboundConfigs[0].Tag); idx > -1 {
 				c.OutboundConfigs[idx] = o.OutboundConfigs[0]
-				newError("<", fn, "> updated outbound with tag: ", o.OutboundConfigs[0].Tag).AtInfo().WriteToLog()
+				ctllog.Println("[", fn, "] updated outbound with tag: ", o.OutboundConfigs[0].Tag)
 			} else {
 				if strings.Contains(strings.ToLower(fn), "tail") {
 					c.OutboundConfigs = append(c.OutboundConfigs, o.OutboundConfigs[0])
-					newError("<", fn, "> appended outbound with tag: ", o.OutboundConfigs[0].Tag).AtInfo().WriteToLog()
+					ctllog.Println("[", fn, "] appended outbound with tag: ", o.OutboundConfigs[0].Tag)
 				} else {
 					c.OutboundConfigs = append(o.OutboundConfigs, c.OutboundConfigs...)
-					newError("<", fn, "> prepended outbound with tag: ", o.OutboundConfigs[0].Tag).AtInfo().WriteToLog()
+					ctllog.Println("[", fn, "] prepended outbound with tag: ", o.OutboundConfigs[0].Tag)
 				}
 			}
 		} else {

--- a/infra/control/command.go
+++ b/infra/control/command.go
@@ -2,6 +2,8 @@ package control
 
 import (
 	"fmt"
+	"log"
+	"os"
 	"strings"
 )
 
@@ -18,6 +20,7 @@ type Command interface {
 
 var (
 	commandRegistry = make(map[string]Command)
+	ctllog          = log.New(os.Stderr, "v2ctl> ", 0)
 )
 
 func RegisterCommand(cmd Command) error {

--- a/infra/control/config.go
+++ b/infra/control/config.go
@@ -37,7 +37,7 @@ func (c *ConfigCommand) Execute(args []string) error {
 
 	conf := &conf.Config{}
 	for _, arg := range args {
-		newError("Reading config: ", arg).AtInfo().WriteToLog()
+		ctllog.Println("Read config: ", arg)
 		r, err := c.LoadArg(arg)
 		common.Must(err)
 		c, err := serial.DecodeJSONConfig(r)

--- a/infra/control/config.go
+++ b/infra/control/config.go
@@ -41,7 +41,9 @@ func (c *ConfigCommand) Execute(args []string) error {
 		r, err := c.LoadArg(arg)
 		common.Must(err)
 		c, err := serial.DecodeJSONConfig(r)
-		common.Must(err)
+		if err != nil {
+			ctllog.Fatalln(err)
+		}
 		conf.Override(c, arg)
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -5,8 +5,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -20,6 +23,7 @@ import (
 
 var (
 	configFiles cmdarg.Arg // "Config file for V2Ray.", the option is customed type, parse in main
+	configDir   string
 	version     = flag.Bool("version", false, "Show current version of V2Ray.")
 	test        = flag.Bool("test", false, "Test config file only, without launching V2Ray server.")
 	format      = flag.String("format", "json", "Format of input file.")
@@ -31,7 +35,25 @@ func fileExists(file string) bool {
 	return err == nil && !info.IsDir()
 }
 
+func dirExists(file string) bool {
+	info, err := os.Stat(file)
+	return err == nil && info.IsDir()
+}
+
+func readConfDir(dirPath string) {
+	confs, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	for _, f := range confs {
+		configFiles.Set(path.Join(dirPath, f.Name()))
+	}
+}
+
 func getConfigFilePath() (cmdarg.Arg, error) {
+	if dirExists(configDir) {
+		readConfDir(configDir)
+	}
 	if len(configFiles) > 0 {
 		return configFiles, nil
 	}
@@ -39,14 +61,25 @@ func getConfigFilePath() (cmdarg.Arg, error) {
 	if workingDir, err := os.Getwd(); err == nil {
 		configFile := filepath.Join(workingDir, "config.json")
 		if fileExists(configFile) {
+			log.Println("Using default config: ", configFile)
 			return cmdarg.Arg{configFile}, nil
 		}
 	}
 
 	if configFile := platform.GetConfigurationPath(); fileExists(configFile) {
+		log.Println("Using config from env: ", configFile)
 		return cmdarg.Arg{configFile}, nil
 	}
 
+	if envConfDir := platform.GetConfDirPath(); dirExists(envConfDir) {
+		log.Println("Using confdir from env: ", envConfDir)
+		readConfDir(envConfDir)
+		if len(configFiles) > 0 {
+			return configFiles, nil
+		}
+	}
+
+	log.Println("Using config from STDIN")
 	return cmdarg.Arg{"stdin:"}, nil
 }
 
@@ -87,7 +120,8 @@ func printVersion() {
 
 func main() {
 	flag.Var(&configFiles, "config", "Config file for V2Ray. Multiple assign is accepted (only json). Latter ones overrides the former ones.")
-	flag.Var(&configFiles, "c", "short alias of -config")
+	flag.Var(&configFiles, "c", "Short alias of -config")
+	flag.StringVar(&configDir, "confdir", "", "A dir with multiple json config")
 	flag.Parse()
 
 	printVersion()

--- a/main/main.go
+++ b/main/main.go
@@ -46,7 +46,9 @@ func readConfDir(dirPath string) {
 		log.Fatalln(err)
 	}
 	for _, f := range confs {
-		configFiles.Set(path.Join(dirPath, f.Name()))
+		if strings.HasSuffix(f.Name(), ".json") {
+			configFiles.Set(path.Join(dirPath, f.Name()))
+		}
 	}
 }
 

--- a/main/main.go
+++ b/main/main.go
@@ -27,7 +27,6 @@ var (
 	version     = flag.Bool("version", false, "Show current version of V2Ray.")
 	test        = flag.Bool("test", false, "Test config file only, without launching V2Ray server.")
 	format      = flag.String("format", "json", "Format of input file.")
-	errNoConfig = newError("no valid config")
 )
 
 func fileExists(file string) bool {
@@ -134,11 +133,8 @@ func main() {
 
 	server, err := startV2Ray()
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println(err)
 		// Configuration error. Exit with a special value to prevent systemd from restarting.
-		if err == errNoConfig {
-			flag.PrintDefaults()
-		}
 		os.Exit(23)
 	}
 


### PR DESCRIPTION
A common way of reading multiple config file is to scan a directory and read config files inside by the order of their names. This PR make multiple config feature more practical by adding `-confdir` arg.

## Adds
* v2ray arg: `-confdir` - A dir with multiple json config
* env `v2ray.location.confdir` or `V2RAY_LOCATION_CONFDIR` 
* more details logs about config during program start.

## Examples

When use with multiple config, lines after `<v2ctl message>` will tell the order of how config file is processed.

```
$ ./v2ray -confdir ./vjson
V2Ray 4.22.0 (V2Fly, a community-driven edition of V2Ray.) Custom
A unified platform for anti-censorship.
2019/12/31 13:45:49 [Info] v2ray.com/core/common/platform/ctlcmd: <v2ctl message> 
v2ctl> Read config:  vjson/01dohipm.json
v2ctl> Read config:  vjson/02doh.json
v2ctl> Read config:  vjson/03out.json
v2ctl> [ vjson/03out.json ] updated outbound with tag:  proxy
2019/12/31 13:45:49 [Debug] v2ray.com/core/app/log: Logger started
...
2019/12/31 13:45:49 [Warning] v2ray.com/core: V2Ray 4.22.0 started
```

So as using env, logs how the config is speculated. (`... Using confdir from env`)
```
$ env V2RAY_LOCATION_CONFDIR=/home/ubuntu/vjson ./v2ray 
V2Ray 4.22.0 (V2Fly, a community-driven edition of V2Ray.) Custom
A unified platform for anti-censorship.
2019/12/31 13:48:02 Using confdir from env:  /home/ubuntu/vjson
2019/12/31 13:48:02 [Info] v2ray.com/core/common/platform/ctlcmd: <v2ctl message> 
v2ctl> Read config:  /home/ubuntu/vjson/01dohipm.json
v2ctl> Read config:  /home/ubuntu/vjson/02doh.json
v2ctl> Read config:  /home/ubuntu/vjson/03out.json
v2ctl> [ /home/ubuntu/vjson/03out.json ] updated outbound with tag:  proxy
2019/12/31 13:48:02 [Warning] v2ray.com/core: V2Ray 4.22.0 started
```

If there's problems in config file, the error message is easy to read
```
$ ./v2ray 
V2Ray 4.22.0 (V2Fly, a community-driven edition of V2Ray.) Custom
A unified platform for anti-censorship.
2019/12/31 14:00:29 Using default config:  /home/ubuntu/config.json
main: failed to read config files: [/home/ubuntu/config.json] > v2ray.com/core/main/json: failed to execute v2ctl to convert config file. > v2ray.com/core/common/platform/ctlcmd: failed to execute v2ctl: 
v2ctl> Read config:  /home/ubuntu/config.json
v2ctl> v2ray.com/core/infra/conf/serial: failed to read config file at line 15 char 5 > invalid character ',' looking for beginning of object key string > exit status 1

```