### PR TITLE
DoH性能问题、DoH下AAAA重新过滤、DNS查询分组订阅

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.DS_Store
 bazel-*
+.idea


### PR DESCRIPTION
1. d520bc2 解决了在请求AAAA记录时，DoH服务器返回A记录的问题，相关issues #2211 
2. be9ce7f 将DNS查询按域名和A和AAAA进行分组订阅，避免了同时查询某域名的A和AAAA记录时，提前sub.Wait()结束，导致在for循环中反复调用s.findIPsForDomain，影响性能。
3. be9ce7f 解决DoH模式下某A/AAAA查询为空的时候在func QueryIP的for循环中无法正确return，反复循环影响性能，且在其后由于timeout而导致轮询DNS服务器，导致在该情况下的DNS请求迟迟无法结束。