### PR TITLE
fix tproxy udp "unable to get destination" in IPv6 environment

### DIFF
--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -3,6 +3,7 @@ package internet
 import (
 	"net"
 	"syscall"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -99,8 +100,10 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 	}
 
 	if config.ReceiveOriginalDestAddress && isUDPSocket(network) {
-		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_RECVORIGDSTADDR, 1); err != nil {
-			return err
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_IPV6, unix.IPV6_RECVORIGDSTADDR, 1); err != nil {
+			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_RECVORIGDSTADDR, 1); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/transport/internet/udp/hub_linux.go
+++ b/transport/internet/udp/hub_linux.go
@@ -5,6 +5,7 @@ package udp
 import (
 	"syscall"
 
+	"golang.org/x/sys/unix"
 	"v2ray.com/core/common/net"
 )
 
@@ -18,7 +19,7 @@ func RetrieveOriginalDest(oob []byte) net.Destination {
 			ip := net.IPAddress(msg.Data[4:8])
 			port := net.PortFromBytes(msg.Data[2:4])
 			return net.UDPDestination(ip, port)
-		} else if msg.Header.Level == syscall.SOL_IPV6 && msg.Header.Type == syscall.IP_RECVORIGDSTADDR {
+		} else if msg.Header.Level == syscall.SOL_IPV6 && msg.Header.Type == unix.IPV6_RECVORIGDSTADDR {
 			ip := net.IPAddress(msg.Data[8:24])
 			port := net.PortFromBytes(msg.Data[2:4])
 			return net.UDPDestination(ip, port)


### PR DESCRIPTION
should use IPV6_RECVORIGDSTADDR. now working as expected.
#1979 #2209 #2214 #2225  
