### PR TITLE
TCP server header: Sending http response hearder immediately instead of waiting for payload

### DIFF
--- a/transport/internet/headers/http/http.go
+++ b/transport/internet/headers/http/http.go
@@ -133,6 +133,14 @@ func (c *HttpConn) Read(b []byte) (int, error) {
 		}
 		c.readBuffer = buffer
 		c.oneTimeReader = nil
+		if c.oneTimeWriter != nil {
+		        err := c.oneTimeWriter.Write(c.Conn)
+		        c.oneTimeWriter = nil
+		        if err != nil {
+			   return 0, err
+		        }
+		}
+
 	}
 
 	if !c.readBuffer.IsEmpty() {


### PR DESCRIPTION
Currently the tcp server response header module only response when there is actual payload to send back, and behaves differently from the normal http procedure, where http response should be sent immediately upon seeing request.

This commit will instead send out http response as soon as oneTimeReader is consumed.