### PR TITLE
fix udp not work in ipv4 using common config

### DIFF
--- a/transport/internet/sockopt_linux.go
+++ b/transport/internet/sockopt_linux.go
@@ -100,10 +100,10 @@ func applyInboundSocketOptions(network string, fd uintptr, config *SocketConfig)
 	}
 
 	if config.ReceiveOriginalDestAddress && isUDPSocket(network) {
-		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_IPV6, unix.IPV6_RECVORIGDSTADDR, 1); err != nil {
-			if err := syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_RECVORIGDSTADDR, 1); err != nil {
-				return err
-			}
+		err1 := syscall.SetsockoptInt(int(fd), syscall.SOL_IPV6, unix.IPV6_RECVORIGDSTADDR, 1)
+		err2 := syscall.SetsockoptInt(int(fd), syscall.SOL_IP, syscall.IP_RECVORIGDSTADDR, 1)
+		if err1 != nil && err2 != nil {
+			return err1
 		}
 	}
 


### PR DESCRIPTION
It seems IPV6_RECVORIGDSTADDR & IP_RECVORIGDSTADDR must be set at the same time when dokodemo-door is listening on "0.0.0.0" so that both IPv4 & IPv6 can work properly.

@ToutyRater @changyp6