### PR TITLE
修复安装脚本添加自启动时报错的问题

### DIFF
--- a/release/install-release.sh
+++ b/release/install-release.sh
@@ -324,9 +324,11 @@ installV2Ray(){
 
 
 installInitScript(){
-    if [[ -n "${SYSTEMCTL_CMD}" ]] && [[ ! -f "/etc/systemd/system/v2ray.service" && ! -f "/lib/systemd/system/v2ray.service" ]]; then
-        unzip -oj "$1" "$2systemd/v2ray.service" -d '/etc/systemd/system' && \
-        systemctl enable v2ray.service
+    if [[ -n "${SYSTEMCTL_CMD}" ]]; then
+        if [[ ! -f "/etc/systemd/system/v2ray.service" && ! -f "/lib/systemd/system/v2ray.service" ]]; then
+            unzip -oj "$1" "$2systemd/v2ray.service" -d '/etc/systemd/system' && \
+            systemctl enable v2ray.service
+        fi
     elif [[ -n "${SERVICE_CMD}" ]] && [[ ! -f "/etc/init.d/v2ray" ]]; then
         installSoftware 'daemon' && \
         unzip -oj "$1" "$2systemv/v2ray" -d '/etc/init.d' && \


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13255981/75985048-83a13e80-5f26-11ea-9112-6559635bbd2d.png)
```
cat /etc/centos-release
CentOS Linux release 7.7.1908 (Core)
```
该系统既有systemd又有systemV，并且之前已经安装过了systemd的启动脚本。现在的逻辑就会走到systemV的安装流程，安装daemon时就会报错。