### PR TITLE
add NoNewPrivileges=yes & CAP_NET_RAW

### DIFF
--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -14,7 +14,8 @@ Type=simple
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
 User=root
 #User=v2ray
-#AmbientCapabilities=CAP_NET_BIND_SERVICE
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
 # Don't restart in the case of configuration error

--- a/release/config/systemd/v2ray@.service
+++ b/release/config/systemd/v2ray@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=V2Ray - A unified platform for anti-censorship - Profile -> %i
+Documentation=https://v2ray.com https://guide.v2fly.org
+After=network.target nss-lookup.target
+Wants=network-online.target
+
+[Service]
+# If the version of systemd is 240 or above, then uncommenting Type=exec and commenting out Type=simple
+#Type=exec
+Type=simple
+# Runs as root or add CAP_NET_BIND_SERVICE ability can bind 1 to 1024 port.
+# This service runs as root. You may consider to run it as another user for security concerns.
+# By uncommenting User=v2ray and commenting out User=root, the service will run as user v2ray.
+# More discussion at https://github.com/v2ray/v2ray-core/issues/1011
+User=root
+#User=v2ray
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+NoNewPrivileges=yes
+ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/%i.json
+Restart=on-failure
+# Don't restart in the case of configuration error
+RestartPreventExitStatus=23
+
+[Install]
+DefaultInstance=default
+WantedBy=multi-user.target


### PR DESCRIPTION
AmbientCapabilities= 换为 CapabilityBoundingSet= 可以缩小默认配置下使用 root 的权限
NoNewPrivileges=yes 可以保证进程不会取得新权限
CapabilityBoundingSet= 增加 CAP_NET_RAW 在普通用户下以获得透明代理的能力

在 a75525262fa60ab8a0c0ca05441b93ab16d43d2c 增加了 v2ray@.service