### PR TITLE
Fix build failure on illumos

### DIFF
--- a/common/buf/readv_posix.go
+++ b/common/buf/readv_posix.go
@@ -1,5 +1,6 @@
 // +build !windows
 // +build !wasm
+// +build !illumos
 
 package buf
 

--- a/common/buf/readv_unix.go
+++ b/common/buf/readv_unix.go
@@ -1,0 +1,36 @@
+// +build illumos
+
+package buf
+
+import "golang.org/x/sys/unix"
+
+type unixReader struct {
+	iovs [][]byte
+}
+
+func (r *unixReader) Init(bs []*Buffer) {
+	iovs := r.iovs
+	if iovs == nil {
+		iovs = make([][]byte, 0, len(bs))
+	}
+	for _, b := range bs {
+		iovs = append(iovs, b.v)
+	}
+	r.iovs = iovs
+}
+
+func (r *unixReader) Read(fd uintptr) int32 {
+	n, e := unix.Readv(int(fd), r.iovs)
+	if e != nil {
+		return -1
+	}
+	return int32(n)
+}
+
+func (r *unixReader) Clear() {
+	r.iovs = r.iovs[:0]
+}
+
+func newMultiReader() multiReader {
+	return &unixReader{}
+}

--- a/transport/internet/domainsocket/listener.go
+++ b/transport/internet/domainsocket/listener.go
@@ -9,8 +9,9 @@ import (
 	gotls "crypto/tls"
 	"os"
 	"strings"
-	"syscall"
 
+	"golang.org/x/sys/unix"
+	
 	"v2ray.com/core/common"
 	"v2ray.com/core/common/net"
 	"v2ray.com/core/transport/internet"
@@ -104,7 +105,7 @@ func (fl *fileLocker) Acquire() error {
 	if err != nil {
 		return err
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
 		f.Close()
 		return newError("failed to lock file: ", fl.path).Base(err)
 	}
@@ -113,7 +114,7 @@ func (fl *fileLocker) Acquire() error {
 }
 
 func (fl *fileLocker) Release() {
-	if err := syscall.Flock(int(fl.file.Fd()), syscall.LOCK_UN); err != nil {
+	if err := unix.Flock(int(fl.file.Fd()), unix.LOCK_UN); err != nil {
 		newError("failed to unlock file: ", fl.path).Base(err).WriteToLog()
 	}
 	if err := fl.file.Close(); err != nil {

--- a/transport/internet/sockopt_other.go
+++ b/transport/internet/sockopt_other.go
@@ -1,4 +1,4 @@
-// +build js dragonfly netbsd openbsd
+// +build js dragonfly netbsd openbsd solaris
 
 package internet
 


### PR DESCRIPTION
Previously v2ray can not be built on illumos due to following reasons:
1. missing build tags in transport/internet/sockopt_other.go
2. many definitions in syscall does not exist on illumos
This commit addresses these problems by adding missing build tags, and
updates those missing syscall deps on illumos to use x/sys/unix.

Fix #2358.