### PR TITLE
fix confdir env startup priority

### DIFF
--- a/main/main.go
+++ b/main/main.go
@@ -35,6 +35,9 @@ func fileExists(file string) bool {
 }
 
 func dirExists(file string) bool {
+	if file == "" {
+		return false
+	}
 	info, err := os.Stat(file)
 	return err == nil && info.IsDir()
 }
@@ -53,8 +56,18 @@ func readConfDir(dirPath string) {
 
 func getConfigFilePath() (cmdarg.Arg, error) {
 	if dirExists(configDir) {
+		log.Println("Using confdir from arg:", configDir)
 		readConfDir(configDir)
+	} else {
+		if envConfDir := platform.GetConfDirPath(); dirExists(envConfDir) {
+			log.Println("Using confdir from env:", envConfDir)
+			readConfDir(envConfDir)
+			if len(configFiles) > 0 {
+				return configFiles, nil
+			}
+		}
 	}
+
 	if len(configFiles) > 0 {
 		return configFiles, nil
 	}
@@ -70,14 +83,6 @@ func getConfigFilePath() (cmdarg.Arg, error) {
 	if configFile := platform.GetConfigurationPath(); fileExists(configFile) {
 		log.Println("Using config from env: ", configFile)
 		return cmdarg.Arg{configFile}, nil
-	}
-
-	if envConfDir := platform.GetConfDirPath(); dirExists(envConfDir) {
-		log.Println("Using confdir from env: ", envConfDir)
-		readConfDir(envConfDir)
-		if len(configFiles) > 0 {
-			return configFiles, nil
-		}
 	}
 
 	log.Println("Using config from STDIN")


### PR DESCRIPTION
In the previous commit, environment var `v2ray.location.confdir` effects only if neither `-config` or `-confdir` specified, it is unintended.

Now the `confdir` effects in the following order:

1. arg `-confdir
2. env `v2ray.location.confdir` or `V2RAY_LOCATION_CONFDIR`