### PR TITLE
add SO_REUSEPORT for freebsd 11

### DIFF
--- a/transport/internet/sockopt_freebsd.go
+++ b/transport/internet/sockopt_freebsd.go
@@ -35,6 +35,7 @@ type pfiocNatlook struct {
 
 const (
 	sizeofPfiocNatlook = 0x4c
+	soReUsePort        = 0x00000200
 	soReUsePortLB      = 0x00010000
 )
 
@@ -192,7 +193,9 @@ func bindAddr(fd uintptr, ip []byte, port uint32) error {
 	}
 
 	if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePortLB, 1); err != nil {
-		return newError("failed to set resuse_port").Base(err).AtWarning()
+		if err := syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, soReUsePort, 1); err != nil {
+			return newError("failed to set resuse_port").Base(err).AtWarning()
+		}
 	}
 
 	var sockaddr syscall.Sockaddr


### PR DESCRIPTION
FreeBSD 11 is a Production Release, so add back required SO_REUSEPORT support.
Still use [SO_REUSEPORT_LB](https://reviews.freebsd.org/D11003) in FreeBSD 12+, which allow multiple programs or threads to bind to the same port and incoming connections will be load balanced using a hash function.
