### PR TITLE
fix config compatibility with old inbound/inboundDetors/out

### DIFF
--- a/infra/conf/v2ray.go
+++ b/infra/conf/v2ray.go
@@ -360,6 +360,21 @@ func (c *Config) Override(o *Config, fn string) {
 		c.Reverse = o.Reverse
 	}
 
+	// deprecated attrs... keep them for now
+	if o.InboundConfig != nil {
+		c.InboundConfig = o.InboundConfig
+	}
+	if o.OutboundConfig != nil {
+		c.OutboundConfig = o.OutboundConfig
+	}
+	if o.InboundDetours != nil {
+		c.InboundDetours = o.InboundDetours
+	}
+	if o.OutboundDetours != nil {
+		c.OutboundDetours = o.OutboundDetours
+	}
+	// deprecated attrs
+
 	// update the Inbound in slice if the only one in overide config has same tag
 	if len(o.InboundConfigs) > 0 {
 		if len(c.InboundConfigs) > 0 && len(o.InboundConfigs) == 1 {

--- a/main/main.go
+++ b/main/main.go
@@ -62,9 +62,6 @@ func getConfigFilePath() (cmdarg.Arg, error) {
 		if envConfDir := platform.GetConfDirPath(); dirExists(envConfDir) {
 			log.Println("Using confdir from env:", envConfDir)
 			readConfDir(envConfDir)
-			if len(configFiles) > 0 {
-				return configFiles, nil
-			}
 		}
 	}
 


### PR DESCRIPTION
multi-config didn't consider depreciated configs.
But since we haven't retire the those depreciated attributes, the support should be continued.