### PR TITLE
about issue #2328 and #2378

### DIFF
--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -18,7 +18,7 @@ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
-#ExecStart=/usr/local/bin/v2ray -confdir /usr/local/etc/v2ray
+#ExecStart=/usr/local/bin/v2ray -confdir /usr/local/etc/v2ray/confdir
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23

--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -15,8 +15,10 @@ Type=simple
 User=root
 #User=v2ray
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
+#ExecStart=/usr/local/bin/v2ray -confdir /usr/local/etc/v2ray
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23

--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -14,7 +14,7 @@ Type=simple
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
 User=root
 #User=v2ray
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json

--- a/release/config/systemd/v2ray.service
+++ b/release/config/systemd/v2ray.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/config.json
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23
+StandardOutput=syslog
 
 [Install]
 WantedBy=multi-user.target

--- a/release/config/systemd/v2ray@.service
+++ b/release/config/systemd/v2ray@.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=V2Ray - A unified platform for anti-censorship - Profile -> %i
+Description=V2Ray - A unified platform for anti-censorship - config -> %i
 Documentation=https://v2ray.com https://guide.v2fly.org
 After=network.target nss-lookup.target
 Wants=network-online.target
@@ -18,7 +18,7 @@ CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/%i.json
-#ExecStart=/usr/local/bin/v2ray -config /usr/local/etc/v2ray/%i.json
+#ExecStart=/usr/local/bin/v2ray -confdir /usr/local/etc/v2ray/%i
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23

--- a/release/config/systemd/v2ray@.service
+++ b/release/config/systemd/v2ray@.service
@@ -14,7 +14,7 @@ Type=simple
 # More discussion at https://github.com/v2ray/v2ray-core/issues/1011
 User=root
 #User=v2ray
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/%i.json

--- a/release/config/systemd/v2ray@.service
+++ b/release/config/systemd/v2ray@.service
@@ -22,6 +22,7 @@ ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/%i.json
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23
+StandardOutput=syslog
 
 [Install]
 DefaultInstance=default

--- a/release/config/systemd/v2ray@.service
+++ b/release/config/systemd/v2ray@.service
@@ -15,8 +15,10 @@ Type=simple
 User=root
 #User=v2ray
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_BIND_SERVICE CAP_NET_RAW
 NoNewPrivileges=yes
 ExecStart=/usr/bin/v2ray/v2ray -config /etc/v2ray/%i.json
+#ExecStart=/usr/local/bin/v2ray -config /usr/local/etc/v2ray/%i.json
 Restart=on-failure
 # Don't restart in the case of configuration error
 RestartPreventExitStatus=23


### PR DESCRIPTION
我之前由于疏忽没有测试透明代理就提交的 service 文件，导致类似 #2378 中描述因为 CapabilityBoundingSet 中没有 CAP_NET_ADMIN 导致无法设置 SO_MARK 的权限问题

目前该 pr 中尚未启用的的 ExecStart= 符合 FHS 并且与 #2328 相似（需要全部迁移使用 confdir）


~~可能需要在合并 #2379 之前合并此 pr~~