### PR TITLE
Some code optimization

### DIFF
--- a/proxy/vmess/validator.go
+++ b/proxy/vmess/validator.go
@@ -146,10 +146,9 @@ func (v *TimedUserValidator) Remove(email string) bool {
 	v.Lock()
 	defer v.Unlock()
 
-	email = strings.ToLower(email)
 	idx := -1
-	for i, u := range v.users {
-		if strings.EqualFold(u.user.Email, email) {
+	for i := range v.users {
+		if strings.EqualFold(v.users[i].user.Email, email) {
 			idx = i
 			break
 		}


### PR DESCRIPTION
* Removed unnecessary `strings.ToLower()`, because below used `strings.EqualFold()`.
* Removed redundant `u` variable, that copy string during each iteration.