### PR TITLE
Add health-check URL parameter to indicate readiness of inbounds with ws/http transport

### DIFF
--- a/transport/internet/http/hub.go
+++ b/transport/internet/http/hub.go
@@ -64,7 +64,11 @@ func (l *Listener) ServeHTTP(writer http.ResponseWriter, request *http.Request) 
 		writer.WriteHeader(404)
 		return
 	}
-
+	if len(request.URL.Query().Get("health")) > 0 {
+		newError("received health check request at path: ", request.URL.Path).WriteToLog()
+		writer.WriteHeader(http.StatusOK)
+		return
+	}
 	writer.Header().Set("Cache-Control", "no-store")
 	writer.WriteHeader(200)
 	if f, ok := writer.(http.Flusher); ok {

--- a/transport/internet/websocket/hub.go
+++ b/transport/internet/websocket/hub.go
@@ -34,6 +34,11 @@ func (h *requestHandler) ServeHTTP(writer http.ResponseWriter, request *http.Req
 		writer.WriteHeader(http.StatusNotFound)
 		return
 	}
+	if len(request.URL.Query().Get("health")) > 0 {
+		newError("received health check request at path: ", request.URL.Path).WriteToLog()
+		writer.WriteHeader(http.StatusOK)
+		return
+	}
 	conn, err := upgrader.Upgrade(writer, request, nil)
 	if err != nil {
 		newError("failed to convert to WebSocket connection").Base(err).WriteToLog()


### PR DESCRIPTION
## Use case 

In cloud native environments such as Google kubernetes Engine, the external ingress controller (Mainly used for TLS termination) needs backend service to expose a valid HTTP health check endpoint.
From the documentation of [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress)
> Health checks
A Service exposed through an Ingress must respond to health checks from the load balancer. Any container that is the final destination of load-balanced traffic must do one of the following to indicate that it is healthy:

It means the external ingress controller will forward requests.to backend service only if the backend health check endpoint returns 200 HTTP code.

Currently, there is no way to check the healthiness of an `Inbound` with ws or http transport. A HTTP GET request to websocket/http path of an `Inbound` will receive `400 Bad Request`, which makes cloud ingress controller "think" the backend service is down, and stops forwarding requests to it.

## What does this PR do

Any request to an inbound (ws/http transport) with a `health` parameter will receive `200 Ok` http response. The value of 'health' key doesn't matter.

For example, `vmess` inbound listen on `8888`, and configured with ws path `/xxx`.

This command will receive `200 OK`.
```shell
curl -v http://127.0.0.1:8888/xxx?health=1
```


The implementation of this PR is ***too simple and naive***, and it only works for `http` and `websocket`. As ingress controller only supports http or ws backend (maybe QUIC), it's not necessary to implement health check for other transport type now. Of course, it would be better if someone implements it for all transport types.