### PR TITLE
fix when domain has no dot

### DIFF
--- a/app/dns/server.go
+++ b/app/dns/server.go
@@ -307,11 +307,6 @@ func (s *Server) lookupIPInternal(domain string, option IPOption) ([]net.IP, err
 		domain = domain[:len(domain)-1]
 	}
 
-	// skip domain without any dot
-	if strings.Index(domain, ".") == -1 {
-		return nil, newError("invalid domain name").AtWarning()
-	}
-
 	ips := s.lookupStatic(domain, option, 0)
 	if ips != nil && ips[0].Family().IsIP() {
 		newError("returning ", len(ips), " IPs for domain ", domain).WriteToLog()


### PR DESCRIPTION
有时候我们会在hosts中自定义一些没有 "." 的域名，这个是完全合法的。
但是如果将这类domain传给v2ray内置的dns模块去解析，会直接return，而不去解析。我认为这是错误的行为。
请大佬review