### PR TITLE
Further strip unique signatures of tls handshake

### DIFF
--- a/app/proxyman/outbound/handler.go
+++ b/app/proxyman/outbound/handler.go
@@ -144,7 +144,7 @@ func (h *Handler) Dial(ctx context.Context, dest net.Destination) (internet.Conn
 				conn := net.NewConnection(net.ConnectionInputMulti(uplinkWriter), net.ConnectionOutputMulti(downlinkReader))
 
 				if config := tls.ConfigFromStreamSettings(h.streamSettings); config != nil {
-					tlsConfig := config.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("h2"))
+					tlsConfig := config.GetTLSConfig(tls.WithDestination(dest))
 					conn = tls.Client(conn, tlsConfig)
 				}
 

--- a/infra/conf/transport_internet.go
+++ b/infra/conf/transport_internet.go
@@ -269,12 +269,13 @@ func (c *TLSCertConfig) Build() (*tls.Certificate, error) {
 }
 
 type TLSConfig struct {
-	Insecure         bool             `json:"allowInsecure"`
-	InsecureCiphers  bool             `json:"allowInsecureCiphers"`
-	Certs            []*TLSCertConfig `json:"certificates"`
-	ServerName       string           `json:"serverName"`
-	ALPN             *StringList      `json:"alpn"`
-	DiableSystemRoot bool             `json:"disableSystemRoot"`
+	Insecure                 bool             `json:"allowInsecure"`
+	InsecureCiphers          bool             `json:"allowInsecureCiphers"`
+	Certs                    []*TLSCertConfig `json:"certificates"`
+	ServerName               string           `json:"serverName"`
+	ALPN                     *StringList      `json:"alpn"`
+	DisableSessionResumption bool             `json:"disableSessionResumption"`
+	DisableSystemRoot        bool             `json:"disableSystemRoot"`
 }
 
 // Build implements Buildable.
@@ -297,7 +298,8 @@ func (c *TLSConfig) Build() (proto.Message, error) {
 	if c.ALPN != nil && len(*c.ALPN) > 0 {
 		config.NextProtocol = []string(*c.ALPN)
 	}
-	config.DisableSystemRoot = c.DiableSystemRoot
+	config.DisableSessionResumption = c.DisableSessionResumption
+	config.DisableSystemRoot = c.DisableSystemRoot
 	return config, nil
 }
 

--- a/transport/internet/http/dialer.go
+++ b/transport/internet/http/dialer.go
@@ -20,12 +20,12 @@ import (
 
 var (
 	globalDialerMap    map[net.Destination]*http.Client
-	globalDailerAccess sync.Mutex
+	globalDialerAccess sync.Mutex
 )
 
 func getHTTPClient(ctx context.Context, dest net.Destination, tlsSettings *tls.Config) (*http.Client, error) {
-	globalDailerAccess.Lock()
-	defer globalDailerAccess.Unlock()
+	globalDialerAccess.Lock()
+	defer globalDialerAccess.Unlock()
 
 	if globalDialerMap == nil {
 		globalDialerMap = make(map[net.Destination]*http.Client)
@@ -54,9 +54,26 @@ func getHTTPClient(ctx context.Context, dest net.Destination, tlsSettings *tls.C
 			if err != nil {
 				return nil, err
 			}
-			return gotls.Client(pconn, tlsConfig), nil
+
+			cn := gotls.Client(pconn, tlsConfig)
+			if err := cn.Handshake(); err != nil {
+				return nil, err
+			}
+			if !tlsConfig.InsecureSkipVerify {
+				if err := cn.VerifyHostname(tlsConfig.ServerName); err != nil {
+					return nil, err
+				}
+			}
+			state := cn.ConnectionState()
+			if p := state.NegotiatedProtocol; p != http2.NextProtoTLS {
+				return nil, newError("http2: unexpected ALPN protocol " + p + "; want q" + http2.NextProtoTLS).AtError()
+			}
+			if !state.NegotiatedProtocolIsMutual {
+				return nil, newError("http2: could not negotiate protocol mutually").AtError()
+			}
+			return cn, nil
 		},
-		TLSClientConfig: tlsSettings.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("h2")),
+		TLSClientConfig: tlsSettings.GetTLSConfig(tls.WithDestination(dest)),
 	}
 
 	client := &http.Client{

--- a/transport/internet/tcp/dialer.go
+++ b/transport/internet/tcp/dialer.go
@@ -21,7 +21,7 @@ func Dial(ctx context.Context, dest net.Destination, streamSettings *internet.Me
 	}
 
 	if config := tls.ConfigFromStreamSettings(streamSettings); config != nil {
-		tlsConfig := config.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("h2"))
+		tlsConfig := config.GetTLSConfig(tls.WithDestination(dest))
 		if config.IsExperiment8357() {
 			conn = tls.UClient(conn, tlsConfig)
 		} else {

--- a/transport/internet/tls/config.go
+++ b/transport/internet/tls/config.go
@@ -176,6 +176,8 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 	config := &tls.Config{
 		ClientSessionCache:     globalSessionCache,
 		RootCAs:                root,
+		InsecureSkipVerify:     c.AllowInsecure,
+		NextProtos:             c.NextProtocol,
 		SessionTicketsDisabled: c.DisableSessionResumption,
 	}
 	if c == nil {
@@ -186,12 +188,6 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		opt(config)
 	}
 
-	if !c.AllowInsecureCiphers && len(config.CipherSuites) == 0 {
-		// crypto/tls will use the proper ciphers
-		config.CipherSuites = nil
-	}
-
-	config.InsecureSkipVerify = c.AllowInsecure
 	config.Certificates = c.BuildCertificates()
 	config.BuildNameToCertificate()
 
@@ -204,11 +200,8 @@ func (c *Config) GetTLSConfig(opts ...Option) *tls.Config {
 		config.ServerName = sn
 	}
 
-	if len(c.NextProtocol) > 0 {
-		config.NextProtos = c.NextProtocol
-	}
 	if len(config.NextProtos) == 0 {
-		config.NextProtos = []string{"http/1.1"}
+		config.NextProtos = []string{"h2", "http/1.1"}
 	}
 
 	return config

--- a/transport/internet/websocket/dialer.go
+++ b/transport/internet/websocket/dialer.go
@@ -45,7 +45,7 @@ func dialWebsocket(ctx context.Context, dest net.Destination, streamSettings *in
 
 	if config := tls.ConfigFromStreamSettings(streamSettings); config != nil {
 		protocol = "wss"
-		dialer.TLSClientConfig = config.GetTLSConfig(tls.WithDestination(dest))
+		dialer.TLSClientConfig = config.GetTLSConfig(tls.WithDestination(dest), tls.WithNextProto("http/1.1"))
 	}
 
 	host := dest.NetAddr()


### PR DESCRIPTION
这个提交里面做了以下几个改动：

- 把tls握手包里默认的alpn设置为`["h2", "http/1.1"]`

之前在GetTLSConfig里有个默认值`["http/1.1"]`，而在实际调用时，h2与tcp模式又显式设置成`["h2"]`。现在除了websocket不得不用`["http/1.1"]`，其余地方统一使用新的默认值。h2链接过程新增通过server返回来协商后的alpn是否是`h2`来判断是否取消链接，而不是之前偷懒式的把client端alpn设置成只有`h2`。做此修改后，tcp模式与h2模式，以及其他使用tls建立连接的地方，alpn都与其他golang程序一致。

- 允许用户在tlsSetting中设置disableSessionResumption参数

设置这个参数的作用是使得ClientHello里没有session_ticket这个扩展。常见的go语言程序的ClientHello里都是没有用这个的，有兴趣的可以自行去查验。不用它的原因，现在h2已经是主流了，都在单个连接里多路复用，这种减少单次连接延迟的手段意义已不大，况且还有安全问题。之前在v2ray的代码里，本来是有这个选项的，然而在v2ctl这边却没有对应，造成实际上不可用。现在在v2ctl里也加上，让他真正生效。个人觉得这个的危险性不如alpn那么大，因此交由用户自己决定是否设置，不改默认值。

（解决 #2522 ）