### PR TITLE
Updated the deprecated ioutil dependency

### DIFF
--- a/app/dns/dohdns.go
+++ b/app/dns/dohdns.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"sync"
@@ -283,11 +282,11 @@ func (s *DoHNameServer) dohHTTPSContext(ctx context.Context, b []byte) ([]byte, 
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		io.Copy(ioutil.Discard, resp.Body) // flush resp.Body so that the conn is reusable
+		io.Copy(io.Discard, resp.Body) // flush resp.Body so that the conn is reusable
 		return nil, fmt.Errorf("DOH server returned code %d", resp.StatusCode)
 	}
 
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func (s *DoHNameServer) findIPsForDomain(domain string, option IPOption) ([]net.IP, error) {

--- a/common/buf/multi_buffer_test.go
+++ b/common/buf/multi_buffer_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"io/ioutil"
 	"os"
 
 	"v2ray.com/core/common"
@@ -121,7 +120,7 @@ func TestMultiBufferReadAllToByte(t *testing.T) {
 		common.Must(err)
 		f.Close()
 
-		cnt, err := ioutil.ReadFile(dat)
+		cnt, err := os.ReadFile(dat)
 		common.Must(err)
 
 		if d := cmp.Diff(buf2, cnt); d != "" {

--- a/common/common.go
+++ b/common/common.go
@@ -5,7 +5,6 @@ package common
 import (
 	"fmt"
 	"go/build"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -69,7 +68,7 @@ func GetRuntimeEnv(key string) (string, error) {
 	}
 	var data []byte
 	var runtimeEnv string
-	data, readErr := ioutil.ReadFile(file)
+	data, readErr := os.ReadFile(file)
 	if readErr != nil {
 		return "", readErr
 	}
@@ -131,7 +130,7 @@ func GetModuleName(pathToProjectRoot string) (string, error) {
 	for {
 		if idx := strings.LastIndex(loopPath, string(filepath.Separator)); idx >= 0 {
 			gomodPath := filepath.Join(loopPath, "go.mod")
-			gomodBytes, err := ioutil.ReadFile(gomodPath)
+			gomodBytes, err := os.ReadFile(gomodPath)
 			if err != nil {
 				loopPath = loopPath[:idx]
 				continue

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -1,7 +1,6 @@
 package log_test
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestFileLogger(t *testing.T) {
-	f, err := ioutil.TempFile("", "vtest")
+	f, err := os.CreateTemp("", "vtest")
 	common.Must(err)
 	path := f.Name()
 	common.Must(f.Close())

--- a/infra/control/config.go
+++ b/infra/control/config.go
@@ -3,7 +3,6 @@ package control
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -71,9 +70,9 @@ func (c *ConfigCommand) LoadArg(arg string) (out io.Reader, err error) {
 	if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
 		data, err = FetchHTTPContent(arg)
 	} else if arg == "stdin:" {
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 	} else {
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/confloader/external/external.go
+++ b/main/confloader/external/external.go
@@ -5,7 +5,6 @@ package external
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,9 +22,9 @@ func ConfigLoader(arg string) (out io.Reader, err error) {
 	if strings.HasPrefix(arg, "http://") || strings.HasPrefix(arg, "https://") {
 		data, err = FetchHTTPContent(arg)
 	} else if arg == "stdin:" {
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 	} else {
-		data, err = ioutil.ReadFile(arg)
+		data, err = os.ReadFile(arg)
 	}
 
 	if err != nil {

--- a/main/main.go
+++ b/main/main.go
@@ -5,7 +5,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -55,7 +54,7 @@ func dirExists(file string) bool {
 }
 
 func readConfDir(dirPath string) {
-	confs, err := ioutil.ReadDir(dirPath)
+	confs, err := os.ReadDir(dirPath)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/proxy/shadowsocks/protocol.go
+++ b/proxy/shadowsocks/protocol.go
@@ -9,7 +9,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"io"
-	"io/ioutil"
 	"v2ray.com/core/common/dice"
 
 	"v2ray.com/core/common"
@@ -99,7 +98,7 @@ func ReadTCPSession(user *protocol.MemoryUser, reader io.Reader) (*protocol.Requ
 }
 
 func DrainConnN(reader io.Reader, n int) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	_, err := io.CopyN(io.Discard, reader, int64(n))
 	return err
 }
 

--- a/proxy/vmess/encoding/server.go
+++ b/proxy/vmess/encoding/server.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"hash/fnv"
 	"io"
-	"io/ioutil"
 	"sync"
 	"time"
 
@@ -484,6 +483,6 @@ func (s *ServerSession) EncodeResponseBody(request *protocol.RequestHeader, writ
 }
 
 func (s *ServerSession) DrainConnN(reader io.Reader, n int) error {
-	_, err := io.CopyN(ioutil.Discard, reader, int64(n))
+	_, err := io.CopyN(io.Discard, reader, int64(n))
 	return err
 }

--- a/testing/scenarios/common.go
+++ b/testing/scenarios/common.go
@@ -5,7 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -101,7 +101,7 @@ func genTestBinaryPath() {
 	testBinaryPathGen.Do(func() {
 		var tempDir string
 		common.Must(retry.Timed(5, 100).On(func() error {
-			dir, err := ioutil.TempDir("", "v2ray")
+			dir, err := os.MkdirTemp("", "v2ray")
 			if err != nil {
 				return err
 			}

--- a/testing/scenarios/feature_test.go
+++ b/testing/scenarios/feature_test.go
@@ -2,7 +2,7 @@ package scenarios
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -641,7 +641,7 @@ func TestDomainSniffing(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Error("unexpected status code: ", resp.StatusCode)
 		}
-		common.Must(resp.Write(ioutil.Discard))
+		common.Must(resp.Write(io.Discard))
 	}
 }
 

--- a/testing/scenarios/http_test.go
+++ b/testing/scenarios/http_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"testing"
@@ -73,7 +72,7 @@ func TestHttpConformance(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if string(content) != "Home" {
 			t.Fatal("body: ", string(content))
@@ -264,7 +263,7 @@ func TestHttpPost(t *testing.T) {
 			t.Fatal("status: ", resp.StatusCode)
 		}
 
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := io.ReadAll(resp.Body)
 		common.Must(err)
 		if r := cmp.Diff(content, xor(payload)); r != "" {
 			t.Fatal(r)
@@ -356,7 +355,7 @@ func TestHttpBasicAuth(t *testing.T) {
 				t.Fatal("status: ", resp.StatusCode)
 			}
 
-			content, err := ioutil.ReadAll(resp.Body)
+			content, err := io.ReadAll(resp.Body)
 			common.Must(err)
 			if string(content) != "Home" {
 				t.Fatal("body: ", string(content))


### PR DESCRIPTION
The ioutil package has been deprecated as of Go v1.16: https://go.dev/doc/go1.16#ioutil This commit replaces ioutil functions with their respective io/os functions.

Please Move to https://github.com/v2fly/v2ray-core/pulls
